### PR TITLE
Add PacketOwned variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Constructing Packets
 ====================
 
 Constructing packets happens using the `Builder` variant of the packet, for example:
-```
+```rust
 use ublox::{CfgPrtUartBuilder, UartPortId, UartMode, DataBits, Parity, StopBits, InProtoMask, OutProtoMask};
 let packet: [u8; 28] = CfgPrtUartBuilder {
    portid: UartPortId::Uart1,
@@ -36,7 +36,7 @@ let packet: [u8; 28] = CfgPrtUartBuilder {
 ```
 
 For variable-size packet like `CfgValSet`, you can construct it into a new `Vec<u8>`:
-```
+```rust
 use ublox::{cfg_val::CfgVal::*, CfgLayer, CfgValSetBuilder};
 let packet_vec: Vec<u8> = CfgValSetBuilder {
     version: 1,
@@ -48,7 +48,7 @@ let packet_vec: Vec<u8> = CfgValSetBuilder {
 let packet: &[u8] = packet_vec.as_slice();
 ```
 Or by extending to an existing one:
-```
+```rust
 let mut packet_vec = Vec::new();
 CfgValSetBuilder {
     version: 1,
@@ -65,7 +65,7 @@ Parsing Packets
 ===============
 
 Parsing packets happens by instantiating a `Parser` object and then adding data into it using its `consume()` method. The parser contains an internal buffer of data, and when `consume()` is called that data is copied into the internal buffer and an iterator-like object is returned to access the packets. For example:
-```
+```rust
 use ublox::Parser;
 let mut parser = Parser::default();
 let my_raw_data = vec![1, 2, 3, 4]; // From your serial port
@@ -73,7 +73,9 @@ let mut it = parser.consume(&my_raw_data);
 loop {
     match it.next() {
         Some(Ok(packet)) => {
-            // We've received a &PacketRef, we can handle it
+            // We've received a &PacketRef, we can handle it here
+            // Or we can convert it to an owned structure, so we can move it
+            let owned_packet = packet.to_owned();
         }
         Some(Err(_)) => {
             // Received a malformed packet

--- a/ublox/src/ubx_packets.rs
+++ b/ublox/src/ubx_packets.rs
@@ -83,9 +83,17 @@ pub trait UbxPacketCreator {
 }
 
 /// Packet not supported yet by this crate
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct UbxUnknownPacketRef<'a> {
     pub payload: &'a [u8],
+    pub class: u8,
+    pub msg_id: u8,
+}
+
+/// Packet not supported yet by this crate
+#[derive(Clone, Debug)]
+pub struct UbxUnknownPacketOwned {
+    pub payload: Vec<u8>,
     pub class: u8,
     pub msg_id: u8,
 }

--- a/ublox_derive/src/output.rs
+++ b/ublox_derive/src/output.rs
@@ -686,7 +686,9 @@ pub fn generate_code_for_parse(recv_packs: &RecvPackets) -> TokenStream {
         });
         matches_owned.push(quote! {
             (#name::CLASS, #name::ID) if <#owned_name>::validate(payload).is_ok()  => {
-                Ok(#union_enum_name_owned::#name(#owned_name([0; #owned_name::PACKET_SIZE])))
+                let mut bytes = [0u8; #owned_name::PACKET_SIZE];
+                bytes.clone_from_slice(payload);
+                Ok(#union_enum_name_owned::#name(#owned_name(bytes)))
             }
         });
         matches_ref_to_owned.push(quote! {


### PR DESCRIPTION
This PR allows to copy parsed packets into data-owned packets that can be moved to other threads.

I'm not really happy about duplicating all the packets and having big matching tables here, but I'm not really sure how else this could be implemented. Maybe refactoring so you have `PacketOwned` as a base data structure that you can borrow from to get `PacketRef`.

Also unintentionally run `cargo fmt` so it cleaned up some other code, which is not that bad in the end (but I can split that into two commits at least if it helps for the review).