### PR TITLE
packets.rs: introduce NavClock and TimTos

### DIFF
--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -3193,6 +3193,7 @@ pub enum TimTm2TimeBase {
 /// Time pulse time & frequency data
 #[ubx_packet_recv]
 #[ubx(class = 0x0D, id = 0x12, fixed_payload_len = 56)]
+#[derive(Debug)]
 struct TimTos {
     version: u8,
     /// GNSS system used for reporting GNSS time
@@ -3240,7 +3241,7 @@ struct TimTos {
 #[ubx_extend_bitflags]
 #[ubx(from, into_raw, rest_reserved)]
 bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Debug)]
     pub struct TimTosFlags: u32 {
         /// Currently in a leap second
         const LEAP_NOW = 0x01;
@@ -4386,16 +4387,6 @@ struct NavAtt {
     acc_heading: u32,
 }
 
-#[ubx_packet_recv]
-#[ubx(class = 0x01, id = 0x22, fixed_payload_len = 20)]
-struct NavClock {
-    itow: u32,
-    clk_b: i32,
-    clk_d: i32,
-    t_acc: u32,
-    f_acc: u32,
-}
-
 #[ubx_extend_bitflags]
 #[ubx(from, rest_reserved)]
 bitflags! {
@@ -4625,7 +4616,6 @@ define_recv_packets!(
         NavHpPosEcef,
         NavTimeUTC,
         NavTimeLs,
-        NavClock,
         NavSat,
         NavEoe,
         NavOdo,

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -227,6 +227,28 @@ struct NavHpPosEcef {
     p_acc: u32,
 }
 
+/// Navigation clock solution,
+/// current receiver clock bias and drift estimates
+#[ubx_packet_recv]
+#[ubx(class = 0x01, id = 0x22, fixed_payload_len = 20)]
+struct NavClock {
+    /// GPS time of week, in s
+    #[ubx(map_type = f64, scale = 1e-3)]
+    itow: u32,
+    /// Receiver clock bias (offset) in s
+    #[ubx(map_type = f64, scale = 1.0E-9)]
+    clk_bias: i32,
+    /// Clock drift (offset variations) [s/s]
+    #[ubx(map_type = f64, scale = 1.0E-9)]
+    clk_drift: i32,
+    /// time accuracy estimate
+    #[ubx(map_type = f64, scale = 1.0E-9)]
+    time_acc: u32,
+    /// frequency accuracy estimate [s/s]
+    #[ubx(map_type = f64, scale = 1.0E-12)]
+    freq_acc: u32,
+}
+
 /// Navigation Position Velocity Time Solution
 #[ubx_packet_recv]
 #[ubx(class = 1, id = 0x07, fixed_payload_len = 92)]
@@ -3168,6 +3190,91 @@ pub enum TimTm2TimeBase {
     Utc,
 }
 
+/// Time pulse time & frequency data
+#[ubx_packet_recv]
+#[ubx(class = 0x0D, id = 0x12, fixed_payload_len = 56)]
+struct TimTos {
+    version: u8,
+    /// GNSS system used for reporting GNSS time
+    gnss_id: u8,
+    reserved1: [u8; 2],
+    #[ubx(map_type = TimTosFlags)]
+    flags: u32,
+    /// Year of UTC time
+    year: u16,
+    /// Month of UTC time
+    month: u8,
+    /// Day of UTC time
+    day: u8,
+    /// Hour of UTC time
+    hour: u8,
+    /// Minute of UTC time
+    minute: u8,
+    /// Second of UTC time
+    second: u8,
+    /// UTC standard identifier
+    #[ubx(map_type = CfgNav5UtcStandard, may_fail)]
+    utc_standard: u8,
+    /// Time offset between preceding pulse and UTC top of second
+    utc_offset: i32,
+    /// Uncertainty of UTC offset
+    utc_uncertainty: u32,
+    /// GNSS week number
+    week: u32,
+    /// GNSS time of week
+    tow: u32,
+    /// Time offset between the preceding pulse and GNSS top of second
+    gnss_offset: i32,
+    /// Uncertainty of GNSS offset
+    gnss_uncertainty: u32,
+    #[ubx(map_type = f64, scale = 2.0E-8)]
+    int_osc_offset: i32,
+    #[ubx(map_type = f64, scale = 2.0E-8)]
+    int_osc_uncertainty: u32,
+    #[ubx(map_type = f64, scale = 2.0E-8)]
+    ext_osc_offset: i32,
+    #[ubx(map_type = f64, scale = 2.0E-8)]
+    ext_osc_uncertainty: u32,
+}
+
+#[ubx_extend_bitflags]
+#[ubx(from, into_raw, rest_reserved)]
+bitflags! {
+    #[derive(Default)]
+    pub struct TimTosFlags: u32 {
+        /// Currently in a leap second
+        const LEAP_NOW = 0x01;
+        /// Leap second in current minute
+        const LEAP_CURRENT_MINUTE = 0x02;
+        /// Positive leap second
+        const POSITIVE_LEAP = 0x04;
+        /// Time pulse is within tolerance limit (Ubx-CfgSmgr)
+        const TIME_IN_LIMIT = 0x08;
+        /// Internal oscillator is within tolerance limit (Ubx-CfgSmgr)
+        const INT_OSC_IN_LIMIT = 0x10;
+        /// Exteranl oscillator is within tolerance limit (Ubx-CfgSmgr)
+        const EXT_OSC_IN_LIMIT = 0x20;
+        /// GNSS Time is valid
+        const GNSS_TIME_IS_VALID = 0x40;
+        /// Disciplining source is GNSS
+        const GNSS_DISCIPLINING = 0x80;
+        /// Disciplining source is EXTINT0
+        const EXTINT0_DISCIPLINING = 0x100;
+        /// Disciplining source is EXTINT1
+        const EXTINT1_DISCIPLINING = 0x200;
+        /// Internal Osc measured by host
+        const INT_MEAS_BY_HOST = 0x400;
+        /// External Osc measured by host
+        const EXT_MEAS_BY_HOST = 0x800;
+        /// (T)RAIM system currently active
+        const RAIM = 0x1000;
+        /// Coherent pulse generation active
+        const COHERENT_PULSE = 0x2000;
+        /// Time pulse is locked
+        const TIME_PULSE_LOCKED = 0x4000;
+    }
+}
+
 #[ubx_packet_recv]
 #[ubx(class = 0x02, id = 0x15, max_payload_len = 8176)] // 16 + 255 * 32
 struct RxmRawx {
@@ -4518,6 +4625,7 @@ define_recv_packets!(
         NavHpPosEcef,
         NavTimeUTC,
         NavTimeLs,
+        NavClock,
         NavSat,
         NavEoe,
         NavOdo,
@@ -4566,6 +4674,7 @@ define_recv_packets!(
         RxmSfrbx,
         EsfRaw,
         TimSvin,
+        TimTos,
         SecUniqId,
     }
 );


### PR DESCRIPTION
Introduce NavClock frame to poll local oscillator estimates and TimTos for 1PPS characteristics

Signed-off-by: Guillaume W. Bres <guillaume.bressaix@gmail.com>