### PR TITLE
Secure id packet

### DIFF
--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -3540,6 +3540,15 @@ impl<'a> core::iter::Iterator for RxmRawxInfoIter<'a> {
     }
 }
 
+/// This message is used to retrieve a unique chip identifier
+#[ubx_packet_recv]
+#[ubx(class = 0x27, id = 0x03, fixed_payload_len = 9)]
+struct SecUniqId {
+    version: u8,
+    reserved1: [u8; 3],
+    unique_id: [u8; 5],
+}
+
 define_recv_packets!(
     enum PacketRef {
         _ = UbxUnknownPacketRef,
@@ -3594,6 +3603,7 @@ define_recv_packets!(
         RxmSfrbx,
         EsfRaw,
         TimSvin,
+        SecUniqId,
     }
 );
 


### PR DESCRIPTION
The support of this packet is important, because of you have more then one ublox device connected to computer,
then you can not distingiush them without support of this packet. Depend on #47 .