### PR TITLE
add hnr messages

### DIFF
--- a/examples/basic_cli/src/main.rs
+++ b/examples/basic_cli/src/main.rs
@@ -8,79 +8,6 @@ use std::convert::TryInto;
 use std::time::Duration;
 use ublox::*;
 
-struct Device {
-    port: Box<dyn serialport::SerialPort>,
-    parser: Parser<Vec<u8>>,
-}
-
-impl Device {
-    pub fn new(port: Box<dyn serialport::SerialPort>) -> Device {
-        let parser = Parser::default();
-        Device { port, parser }
-    }
-
-    pub fn write_all(&mut self, data: &[u8]) -> std::io::Result<()> {
-        self.port.write_all(data)
-    }
-
-    pub fn update<T: FnMut(PacketRef)>(&mut self, mut cb: T) -> std::io::Result<()> {
-        loop {
-            let mut local_buf = [0; 100];
-            let nbytes = self.read_port(&mut local_buf)?;
-            if nbytes == 0 {
-                break;
-            }
-
-            // parser.consume adds the buffer to its internal buffer, and
-            // returns an iterator-like object we can use to process the packets
-            let mut it = self.parser.consume(&local_buf[..nbytes]);
-            loop {
-                match it.next() {
-                    Some(Ok(packet)) => {
-                        cb(packet);
-                    },
-                    Some(Err(_)) => {
-                        // Received a malformed packet, ignore it
-                    },
-                    None => {
-                        // We've eaten all the packets we have
-                        break;
-                    },
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub fn wait_for_ack<T: UbxPacketMeta>(&mut self) -> std::io::Result<()> {
-        let mut found_packet = false;
-        while !found_packet {
-            self.update(|packet| {
-                if let PacketRef::AckAck(ack) = packet {
-                    if ack.class() == T::CLASS && ack.msg_id() == T::ID {
-                        found_packet = true;
-                    }
-                }
-            })?;
-        }
-        Ok(())
-    }
-
-    /// Reads the serial port, converting timeouts into "no data received"
-    fn read_port(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
-        match self.port.read(output) {
-            Ok(b) => Ok(b),
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::TimedOut {
-                    Ok(0)
-                } else {
-                    Err(e)
-                }
-            },
-        }
-    }
-}
-
 fn main() {
     let matches = Command::new("uBlox CLI example program")
         .author(clap::crate_authors!())
@@ -172,11 +99,10 @@ fn main() {
         .wait_for_ack::<CfgPrtUart>()
         .expect("Could not acknowledge UBX-CFG-PRT-UART msg");
 
-    // Enable the NavPosVelTime packet
+    // Enable the NavPvt packet
     device
         .write_all(
-            &CfgMsgAllPortsBuilder::set_rate_for::<NavPosVelTime>([0, 1, 0, 0, 0, 0])
-                .into_packet_bytes(),
+            &CfgMsgAllPortsBuilder::set_rate_for::<NavPvt>([0, 1, 0, 0, 0, 0]).into_packet_bytes(),
         )
         .expect("Could not configure ports for UBX-NAV-PVT");
     device
@@ -202,7 +128,7 @@ fn main() {
                     );
                     println!("{:?}", packet);
                 },
-                PacketRef::NavPosVelTime(sol) => {
+                PacketRef::NavPvt(sol) => {
                     let has_time = sol.fix_type() == GpsFix::Fix3D
                         || sol.fix_type() == GpsFix::GPSPlusDeadReckoning
                         || sol.fix_type() == GpsFix::TimeOnlyFix;
@@ -235,5 +161,79 @@ fn main() {
                 },
             })
             .unwrap();
+    }
+}
+
+struct Device {
+    port: Box<dyn serialport::SerialPort>,
+    parser: Parser<Vec<u8>>,
+}
+
+impl Device {
+    pub fn new(port: Box<dyn serialport::SerialPort>) -> Device {
+        let parser = Parser::default();
+        Device { port, parser }
+    }
+
+    pub fn write_all(&mut self, data: &[u8]) -> std::io::Result<()> {
+        self.port.write_all(data)
+    }
+
+    pub fn update<T: FnMut(PacketRef)>(&mut self, mut cb: T) -> std::io::Result<()> {
+        loop {
+            const MAX_PAYLOAD_LEN: usize = 1240;
+            let mut local_buf = [0; MAX_PAYLOAD_LEN];
+            let nbytes = self.read_port(&mut local_buf)?;
+            if nbytes == 0 {
+                break;
+            }
+
+            // parser.consume adds the buffer to its internal buffer, and
+            // returns an iterator-like object we can use to process the packets
+            let mut it = self.parser.consume(&local_buf[..nbytes]);
+            loop {
+                match it.next() {
+                    Some(Ok(packet)) => {
+                        cb(packet);
+                    },
+                    Some(Err(_)) => {
+                        // Received a malformed packet, ignore it
+                    },
+                    None => {
+                        // We've eaten all the packets we have
+                        break;
+                    },
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn wait_for_ack<T: UbxPacketMeta>(&mut self) -> std::io::Result<()> {
+        let mut found_packet = false;
+        while !found_packet {
+            self.update(|packet| {
+                if let PacketRef::AckAck(ack) = packet {
+                    if ack.class() == T::CLASS && ack.msg_id() == T::ID {
+                        found_packet = true;
+                    }
+                }
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Reads the serial port, converting timeouts into "no data received"
+    fn read_port(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        match self.port.read(output) {
+            Ok(b) => Ok(b),
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::TimedOut {
+                    Ok(0)
+                } else {
+                    Err(e)
+                }
+            },
+        }
     }
 }

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -161,7 +161,7 @@ struct NavHpPosLlh {
 /// Navigation Position Velocity Time Solution
 #[ubx_packet_recv]
 #[ubx(class = 1, id = 0x07, fixed_payload_len = 92)]
-struct NavPosVelTime {
+struct NavPvt {
     /// GPS Millisecond Time of Week
     itow: u32,
     year: u16,
@@ -177,9 +177,9 @@ struct NavPosVelTime {
     /// GNSS fix Type
     #[ubx(map_type = GpsFix)]
     fix_type: u8,
-    #[ubx(map_type = NavPosVelTimeFlags)]
+    #[ubx(map_type = NavPvtFlags)]
     flags: u8,
-    #[ubx(map_type = NavPosVelTimeFlags2)]
+    #[ubx(map_type = NavPvtFlags2)]
     flags2: u8,
     num_satellites: u8,
     #[ubx(map_type = f64, scale = 1e-7, alias = lon_degrees)]
@@ -239,9 +239,9 @@ struct NavPosVelTime {
 #[ubx_extend_bitflags]
 #[ubx(from, rest_reserved)]
 bitflags! {
-    /// Fix status flags for `NavPosVelTime`
+    /// Fix status flags for `NavPvt`
     #[derive(Debug)]
-    pub struct NavPosVelTimeFlags: u8 {
+    pub struct NavPvtFlags: u8 {
         /// position and velocity valid and within DOP and ACC Masks
         const GPS_FIX_OK = 1;
         /// DGPS used
@@ -256,9 +256,9 @@ bitflags! {
 #[ubx_extend_bitflags]
 #[ubx(from, rest_reserved)]
 bitflags! {
-    /// Additional flags for `NavPosVelTime`
+    /// Additional flags for `NavPvt`
     #[derive(Debug)]
-    pub struct NavPosVelTimeFlags2: u8 {
+    pub struct NavPvtFlags2: u8 {
         /// 1 = information about UTC Date and Time of Day validity confirmation
         /// is available. This flag is only supported in Protocol Versions
         /// 19.00, 19.10, 20.10, 20.20, 20.30, 22.00, 23.00, 23.01,27 and 28.
@@ -3522,7 +3522,7 @@ define_recv_packets!(
         NavPosLlh,
         NavStatus,
         NavDop,
-        NavPosVelTime,
+        NavPvt,
         NavSolution,
         NavVelNed,
         NavHpPosLlh,

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -3247,16 +3247,25 @@ struct HnrPvt {
 
     #[ubx(map_type = f64, scale = 1e-7, alias = longitude)]
     lon: i32,
+
     #[ubx(map_type = f64, scale = 1e-7, alias = latitude)]
     lat: i32,
 
+    #[ubx(map_type = f64, scale = 1e-3, alias = height_above_ellipsoid)]
     height: i32,
+
+    #[ubx(map_type = f64, scale = 1e-3, alias = height_msl)]
     height_msl: i32,
+
+    #[ubx(map_type = f64, scale = 1e-3, alias = ground_speed_2d)]
     g_speed: i32,
+
+    #[ubx(map_type = f64, scale = 1e-3, alias = speed_3d)]
     speed: i32,
 
     #[ubx(map_type = f64, scale = 1e-5, alias = heading_motion)]
     head_mot: i32,
+
     #[ubx(map_type = f64, scale = 1e-5, alias = heading_vehicle)]
     head_veh: i32,
 

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -3183,7 +3183,7 @@ impl<'a> core::iter::Iterator for EsfRawDataIter<'a> {
 #[ubx_packet_recv]
 #[ubx(class = 0x10, id = 0x15, fixed_payload_len = 36)]
 struct EsfIns {
-    // #[ubx(map_type = EsfInsBitFlags)]
+    #[ubx(map_type = EsfInsBitFlags)]
     bit_field: u32,
     reserved: [u8; 4],
     i_tow: u32,
@@ -3212,6 +3212,68 @@ struct EsfIns {
 bitflags! {
     #[derive(Debug)]
     pub struct EsfInsBitFlags: u32 {
+        const VERSION = 1;
+        const X_ANG_RATE_VALID = 0x100;
+        const Y_ANG_RATE_VALID = 0x200;
+        const Z_ANG_RATE_VALID = 0x400;
+        const X_ACCEL_VALID = 0x800;
+        const Y_ACCEL_VALID = 0x1000;
+        const Z_ACCEL_VALID = 0x2000;
+    }
+}
+
+#[ubx_packet_recv]
+#[ubx(class = 0x28, id = 0x01, fixed_payload_len = 32)]
+struct HnrAtt {
+    itow: u32,
+    version: u8,
+    reserved1: [u8; 3],
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_roll)]
+    roll: i32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_pitch)]
+    pitch: i32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_heading)]
+    heading: i32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_roll_accuracy)]
+    acc_roll: u32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_pitch_accuracy)]
+    acc_pitch: u32,
+    #[ubx(map_type = f64, scale = 1e-5, alias = vehicle_heading_accuracy)]
+    acc_heading: u32,
+}
+
+#[ubx_packet_recv]
+#[ubx(class = 0x28, id = 0x02, fixed_payload_len = 36)]
+pub struct HnrIns {
+    #[ubx(map_type = HnrInsBitFlags)]
+    bit_field: u32,
+    reserved: [u8; 4],
+    i_tow: u32,
+
+    #[ubx(map_type = f64, scale = 1e-3, alias = x_angular_rate)]
+    x_ang_rate: i32,
+
+    #[ubx(map_type = f64, scale = 1e-3, alias = y_angular_rate)]
+    y_ang_rate: i32,
+
+    #[ubx(map_type = f64, scale = 1e-3, alias = z_angular_rate)]
+    z_ang_rate: i32,
+
+    #[ubx(map_type = f64, scale = 1e-2, alias = x_acceleration)]
+    x_accel: i32,
+
+    #[ubx(map_type = f64, scale = 1e-2, alias = y_acceleration)]
+    y_accel: i32,
+
+    #[ubx(map_type = f64, scale = 1e-2, alias = z_acceleration)]
+    z_accel: i32,
+}
+
+#[ubx_extend_bitflags]
+#[ubx(from, rest_reserved)]
+bitflags! {
+    #[derive(Debug)]
+    pub struct HnrInsBitFlags: u32 {
         const VERSION = 1;
         const X_ANG_RATE_VALID = 0x100;
         const Y_ANG_RATE_VALID = 0x200;
@@ -3571,6 +3633,8 @@ define_recv_packets!(
         RxmRtcm,
         EsfMeas,
         EsfIns,
+        HnrAtt,
+        HnrIns,
         HnrPvt,
         NavAtt,
         NavClock,

--- a/ublox/src/ubx_packets/types.rs
+++ b/ublox/src/ubx_packets/types.rs
@@ -3,7 +3,7 @@ use crate::error::DateTimeError;
 use chrono::prelude::*;
 use core::{convert::TryFrom, fmt};
 
-/// Represents a world position, can be constructed from NavPosLlh and NavPosVelTime packets.
+/// Represents a world position, can be constructed from NavPosLlh and NavPvt packets.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy)]
 pub struct Position {
@@ -56,8 +56,8 @@ impl<'a> From<&NavVelNedRef<'a>> for Velocity {
     }
 }
 
-impl<'a> From<&NavPosVelTimeRef<'a>> for Position {
-    fn from(packet: &NavPosVelTimeRef<'a>) -> Self {
+impl<'a> From<&NavPvtRef<'a>> for Position {
+    fn from(packet: &NavPvtRef<'a>) -> Self {
         Position {
             lon: packet.lon_degrees(),
             lat: packet.lat_degrees(),
@@ -66,8 +66,8 @@ impl<'a> From<&NavPosVelTimeRef<'a>> for Position {
     }
 }
 
-impl<'a> From<&NavPosVelTimeRef<'a>> for Velocity {
-    fn from(packet: &NavPosVelTimeRef<'a>) -> Self {
+impl<'a> From<&NavPvtRef<'a>> for Velocity {
+    fn from(packet: &NavPvtRef<'a>) -> Self {
         Velocity {
             speed: packet.ground_speed(),
             heading: packet.heading_degrees(),
@@ -75,9 +75,9 @@ impl<'a> From<&NavPosVelTimeRef<'a>> for Velocity {
     }
 }
 
-impl<'a> TryFrom<&NavPosVelTimeRef<'a>> for DateTime<Utc> {
+impl<'a> TryFrom<&NavPvtRef<'a>> for DateTime<Utc> {
     type Error = DateTimeError;
-    fn try_from(sol: &NavPosVelTimeRef<'a>) -> Result<Self, Self::Error> {
+    fn try_from(sol: &NavPvtRef<'a>) -> Result<Self, Self::Error> {
         let date = NaiveDate::from_ymd_opt(
             i32::from(sol.year()),
             u32::from(sol.month()),


### PR DESCRIPTION
Renames `NavPosVelTime` message to NAV-PVT to adhere to UBX naming.
Adds HNR-ATT and HNR-INS messages. 