### PR TITLE
Improve support for embedded targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,12 +35,6 @@ jobs:
       run: |
         cargo fmt --all -- --check
         cargo clippy --all-features --all-targets -- -D warnings
-    - name: Examples - build
-      run: cd ${{ github.workspace }} && cargo build
-    - name: Examples - coding style
-      run: |
-        cd ${{ github.workspace }} && cargo fmt --all -- --check
-        cd ${{ github.workspace }} && cargo clippy --all-features --all-targets -- -D warnings
 
   build_embedded:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,7 @@ jobs:
         feature-args:
           - ''
           - --no-default-features --features alloc
+          - --no-default-features --features serde
           - --no-default-features
     steps:
     - uses: actions/checkout@v4
@@ -54,6 +55,10 @@ jobs:
       run: rustup target add thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabihf
     - name: Build
       run: cargo build --verbose --no-default-features --target thumbv6m-none-eabi --target thumbv7m-none-eabi --target thumbv7em-none-eabihf
+    - name: Build (alloc)
+      run: cargo build --verbose --no-default-features --target thumbv6m-none-eabi --target thumbv7m-none-eabi --target thumbv7em-none-eabihf --features alloc
+    - name: Build (serde)
+      run: cargo build --verbose --no-default-features --target thumbv6m-none-eabi --target thumbv7m-none-eabi --target thumbv7em-none-eabihf --features serde
 
   build_examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
           - --no-default-features --features alloc
           - --no-default-features
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install libudev
       run: sudo apt-get update && sudo apt-get install -y libudev-dev
     - name: Install MSRV
@@ -41,10 +41,24 @@ jobs:
         cd ${{ github.workspace }} && cargo fmt --all -- --check
         cd ${{ github.workspace }} && cargo clippy --all-features --all-targets -- -D warnings
 
+  build_embedded:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install MSRV
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.70.0
+        override: true
+    - name: Install embedded targets
+      run: rustup target add thumbv6m-none-eabi thumbv7m-none-eabi thumbv7em-none-eabihf
+    - name: Build
+      run: cargo build --verbose --no-default-features --target thumbv6m-none-eabi --target thumbv7m-none-eabi --target thumbv7em-none-eabihf
+
   build_examples:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install libudev
       run: sudo apt-get update && sudo apt-get install -y libudev-dev
     - name: Install MSRV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["ublox", "ublox_derive"]
+resolver = "2"

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -25,6 +25,15 @@ use super::{
     UbxUnknownPacketRef, SYNC_CHAR_1, SYNC_CHAR_2,
 };
 
+/// Used to help serialize the packet's fields flattened within a struct containing the msg_id and class fields, but
+/// without using the serde FlatMapSerializer which requires alloc.
+#[cfg(feature = "serde")]
+pub(crate) trait SerializeUbxPacketFields {
+    fn serialize_fields<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+    where
+        S: serde::ser::SerializeMap;
+}
+
 /// Geodetic Position Solution
 #[ubx_packet_recv]
 #[ubx(class = 1, id = 2, fixed_payload_len = 28)]


### PR DESCRIPTION
I wasn't able to build ublox for embedded targets, because dependencies like `bitflags` and `num-traits` were both dependencies and transitive dev-dependencies and would get their `std` features enabled as dev-dependencies, and thus wouldn't build for the no_std target. To fix that I set resolver = 2 in the workspace `Cargo.toml`. (Resolver = 2 is the default for the 2021 edition, *but not* when inside of a workspace)

I then noticed that it wasn't possible to build ublox with the `serde` feature but without the `std` feature, because serde's implementation for flat map serialization uses a vec sometimes, and thus requires `alloc`. We can work around this by manually implementing serialize in a flattened manner rather than using `derive(Serialize)` .