### PR TITLE
Implement NavHpPosEcef message and PositionECEF

### DIFF
--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "ublox"
 readme = "../README.md"
 repository = "https://github.com/lkolbly/ublox"
-version = "0.4.5"
+version = "0.4.6"
 
 [features]
 alloc = []

--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "ublox"
 readme = "../README.md"
 repository = "https://github.com/lkolbly/ublox"
-version = "0.4.6"
+version = "0.4.5"
 
 [features]
 alloc = []

--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "ublox"
 readme = "../README.md"
 repository = "https://github.com/lkolbly/ublox"
-version = "0.4.4"
+version = "0.4.5"
 
 [features]
 alloc = []

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -172,8 +172,6 @@ struct NavHpPosLlh {
 bitflags! {
     #[derive(Default, Debug)]
     pub struct NavHpPosEcefFlags: u8 {
-        /// Position given in LAT/LON/ALT
-        /// default being WGS84 ECEF
         const INVALID_ECEF = 1;
 
     }

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -167,6 +167,68 @@ struct NavHpPosLlh {
     vertical_accuracy: u32,
 }
 
+#[ubx_extend_bitflags]
+#[ubx(from, into_raw, rest_reserved)]
+bitflags! {
+    #[derive(Default, Debug)]
+    pub struct NavHpPosEcefFlags: u8 {
+        /// Position given in LAT/LON/ALT
+        /// default being WGS84 ECEF
+        const INVALID_ECEF = 1;
+
+    }
+}
+
+/// High Precision Geodetic Position Solution (ECEF)
+#[ubx_packet_recv]
+#[ubx(class = 0x01, id = 0x13, fixed_payload_len = 28)]
+struct NavHpPosEcef {
+    /// Message version (0 for protocol version 27)
+    version: u8,
+
+    reserved1: [u8; 3],
+
+    /// GPS Millisecond Time of Week
+    itow: u32,
+
+    /// ECEF X coordinate
+    #[ubx(map_type = f64, alias = ecef_x_cm)]
+    ecef_x: i32,
+
+    /// ECEF Y coordinate
+    #[ubx(map_type = f64, alias = ecef_y_cm)]
+    ecef_y: i32,
+
+    /// ECEF Z coordinate
+    #[ubx(map_type = f64, alias = ecef_z_cm)]
+    ecef_z: i32,
+
+    /// High precision component of X
+    /// Must be in the range -99..+99
+    /// Precise coordinate in cm = ecef_x + (ecef_x_hp * 1e-2).
+    #[ubx(map_type = f64, scale = 1e-1, alias = ecef_x_hp_mm)]
+    ecef_x_hp: i8,
+
+    /// High precision component of Y
+    /// Must be in the range -99..+99
+    /// 9. Precise coordinate in cm = ecef_y + (ecef_y_hp * 1e-2).
+    #[ubx(map_type = f64, scale = 1e-1, alias = ecef_y_hp_mm)]
+    ecef_y_hp: i8,
+
+    /// High precision component of Z
+    /// Must be in the range -99..+99
+    /// Precise coordinate in cm = ecef_z + (ecef_z_hp * 1e-2).
+    #[ubx(map_type = f64, scale = 1e-1, alias = ecef_z_hp_mm)]
+    ecef_z_hp: i8,
+
+    #[ubx(map_type = NavHpPosEcefFlags)]
+    flags: u8,
+
+    /// Horizontal accuracy estimate (mm)
+    #[ubx(map_type = f64, scale = 1e-1)]
+    p_acc: u32,
+}
+
 /// Navigation Position Velocity Time Solution
 #[ubx_packet_recv]
 #[ubx(class = 1, id = 0x07, fixed_payload_len = 92)]

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -3666,6 +3666,7 @@ define_recv_packets!(
         NavSolution,
         NavVelNed,
         NavHpPosLlh,
+        NavHpPosEcef,
         NavTimeUTC,
         NavTimeLs,
         NavSat,

--- a/ublox/src/ubx_packets/types.rs
+++ b/ublox/src/ubx_packets/types.rs
@@ -31,7 +31,6 @@ pub struct PositionECEF {
     pub z: f64,
 }
 
-
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Velocity {
@@ -71,7 +70,6 @@ impl<'a> From<&NavHpPosEcefRef<'a>> for PositionECEF {
         }
     }
 }
-
 
 impl<'a> From<&NavVelNedRef<'a>> for Velocity {
     fn from(packet: &NavVelNedRef<'a>) -> Self {

--- a/ublox/src/ubx_packets/types.rs
+++ b/ublox/src/ubx_packets/types.rs
@@ -21,13 +21,13 @@ pub struct Position {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Copy)]
 pub struct PositionECEF {
-    /// Logitude in degrees
+    /// x coordinates in meters
     pub x: f64,
 
-    /// Latitude in degrees
+    /// y coordinates in meters
     pub y: f64,
 
-    /// Altitude in meters
+    /// z coordinates in meters
     pub z: f64,
 }
 

--- a/ublox/src/ubx_packets/types.rs
+++ b/ublox/src/ubx_packets/types.rs
@@ -17,6 +17,21 @@ pub struct Position {
     pub alt: f64,
 }
 
+/// Represents a world position in the ECEF coordinate system
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy)]
+pub struct PositionECEF {
+    /// Logitude in degrees
+    pub x: f64,
+
+    /// Latitude in degrees
+    pub y: f64,
+
+    /// Altitude in meters
+    pub z: f64,
+}
+
+
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Velocity {
@@ -46,6 +61,17 @@ impl<'a> From<&NavHpPosLlhRef<'a>> for Position {
         }
     }
 }
+
+impl<'a> From<&NavHpPosEcefRef<'a>> for PositionECEF {
+    fn from(packet: &NavHpPosEcefRef<'a>) -> Self {
+        PositionECEF {
+            x: 10e-2 * (packet.ecef_x_cm() + 0.1 * packet.ecef_x_hp_mm()),
+            y: 10e-2 * (packet.ecef_y_cm() + 0.1 * packet.ecef_y_hp_mm()),
+            z: 10e-2 * (packet.ecef_z_cm() + 0.1 * packet.ecef_z_hp_mm()),
+        }
+    }
+}
+
 
 impl<'a> From<&NavVelNedRef<'a>> for Velocity {
     fn from(packet: &NavVelNedRef<'a>) -> Self {


### PR DESCRIPTION
The message has been implemented according to [this datasheet](https://cdn.sparkfun.com/assets/f/7/4/3/5/PM-15136.pdf#page=157&zoom=100,0,338).
The type has been implemented analog to PositionLLH.