### PR TITLE
Add L5 "ignore health bit" command

### DIFF
--- a/ublox/src/ubx_packets/cfg_val.rs
+++ b/ublox/src/ubx_packets/cfg_val.rs
@@ -1094,6 +1094,10 @@ cfg_val! {
   SignalGloL1Ena,        0x10310018, bool,
   SignalGLoL2Ena,        0x1031001a, bool,
 
+  /// "Undocumented" L5 Health Bit Ignore (see
+  /// https://content.u-blox.com/sites/default/files/documents/GPS-L5-configuration_AppNote_UBX-21038688.pdf)
+  UndocumentedL5Enable,  0x10320001, bool,
+
   // CFG-TP-*
   TpPulseDef,            0x20050023, TpPulse,
   TpPulseLengthDef,      0x20050030, TpPulseLength,


### PR DESCRIPTION
While not formally part of the F9P interface description, UBLOX modules with L5 support come with L5 "ignored" by default, since it ignores satellites with the health bit set to unhealthy.

See: https://content.u-blox.com/sites/default/files/documents/GPS-L5-configuration_AppNote_UBX-21038688.pdf

The solution is to send a configuration command, which they present as a byte string. In effect, this is just a configuration command. I added it as a value in the CfgVal enum.

