### PR TITLE
Fix CI release script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,13 +103,13 @@ jobs:
         run: |
             cd ublox_derive
             RUSTDOCFLAGS="--cfg docrs" \
-                cargo +nightly doc --no-deps --all-features
+                cargo +nightly doc --no-deps
       
       - name: ublox
         run: |
             cd ublox
             RUSTDOCFLAGS="--cfg docrs" \
-                cargo +nightly doc --no-deps --all-features
+                cargo +nightly doc --no-deps
 
   msrv:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,30 @@ jobs:
       run: |
           cargo fmt --all -- --check
           cargo clippy --all-targets -- -D warnings
+  
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+    
+      - name: Install nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+
+      - name: ublox_derive
+        run: |
+            cd ublox_derive
+            RUSTDOCFLAGS="--cfg docrs" \
+                cargo +nightly doc --no-deps --all-features
+      
+      - name: ublox
+        run: |
+            cd ublox
+            RUSTDOCFLAGS="--cfg docrs" \
+                cargo +nightly doc --no-deps --all-features
 
   msrv:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   publish_derive:
-    name: Publish
+    name: Publish derive
     runs-on: ubuntu-latest
     continue-on-error: true
     if: github.ref_type == 'tag'
@@ -27,7 +27,7 @@ jobs:
         run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }} -p ublox_derive
 
   publish_ublox:
-    name: Publish
+    name: Publish ublox
     needs: ['publish_derive']
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -41,7 +41,7 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Publish
+      - name: Publish 
         run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }} -p ublox
   
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           toolchain: stable
 
       - name: Publish
-        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }} --allow-dirty -p ublox_derive
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }} -p ublox_derive
 
   publish_ublox:
     name: Publish
@@ -42,7 +42,7 @@ jobs:
           toolchain: stable
 
       - name: Publish
-        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }} --allow-dirty -p ublox
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }} -p ublox
   
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
 
   publish_ublox:
     name: Publish
+    needs: ['publish_derive']
     runs-on: ubuntu-latest
     continue-on-error: true
     if: github.ref_type == 'tag'

--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -18,6 +18,10 @@ default = ["std", "serde", "ubx_proto23"]
 alloc = []
 std = []
 
+[package.metadata.docs.rs]
+all-features = false
+rustdoc-args = ["--cfg", "docrs", "--generate-link-to-definition"]
+
 [dependencies]
 bitflags = "2.3"
 chrono = { version = "0.4", default-features = false, features = [] }


### PR DESCRIPTION
  * Ublox-rs needs ublox_derive to be released first
  * continue-on-error: permits ublox_derive publication failure and ublox publication success, when only releasing the latter
  * ublox auto-docs is currently in failure, not sure why it is not picked up yet by CI. I introduce a job dedicated to lib documentations