### PR TITLE
Packet owned variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Add owned variants of `PacketRef` ([#103](https://github.com/ublox-rs/ublox/pull/103))
+
 ## [0.5.0] - 2025-03-17
 
 ### 💼 What's Changed
 
 - Prepare for next release ([#95](https://github.com/ublox-rs/ublox/pull/95))
   - remove duplicate CI file
-  - cherry-picked NavSig from PR [#73](https://github.com/ublox-rs/ublox/pull/73)
+  - cherry-picked NavSig from PR ([#73](https://github.com/ublox-rs/ublox/pull/73))
   - add semver to CI
 - Added comments and scaling for NavRelPosNed packets ([#93](https://github.com/ublox-rs/ublox/pull/93))
 - Separate PacketRef enum into own file and CI improvements ([#94](https://github.com/ublox-rs/ublox/pull/94))

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Parsing packets happens by instantiating a `Parser` object and then adding data 
         match it.next() {
             Some(Ok(packet)) => {
                 // We've received a &PacketRef, we can handle it
+                // Or we can convert it to an owned structure, so we can move it
+                let owned_packet = packet.to_owned();
             }
             Some(Err(_)) => {
                 // Received a malformed packet

--- a/ublox/src/parser.rs
+++ b/ublox/src/parser.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use crate::{
     error::ParserError,
     ubx_packets::{
-        packetref::{match_packet, Packet, MAX_PAYLOAD_LEN},
+        packetref::{match_packet, PacketRef, MAX_PAYLOAD_LEN},
         SYNC_CHAR_1, SYNC_CHAR_2,
     },
 };
@@ -424,7 +424,7 @@ impl<T: UnderlyingBuffer> ParserIter<'_, T> {
         (0..self.buf.len()).find(|&i| self.buf[i] == SYNC_CHAR_1)
     }
 
-    fn extract_packet(&mut self, pack_len: usize) -> Option<Result<Packet, ParserError>> {
+    fn extract_packet(&mut self, pack_len: usize) -> Option<Result<PacketRef, ParserError>> {
         if !self.buf.can_drain_and_take(6, pack_len + 2) {
             if self.buf.potential_lost_bytes() > 0 {
                 // We ran out of space, drop this packet and move on
@@ -468,7 +468,7 @@ impl<T: UnderlyingBuffer> ParserIter<'_, T> {
     #[allow(clippy::should_implement_trait)]
     /// Analog of `core::iter::Iterator::next`, should be switched to
     /// trait implementation after merge of `<https://github.com/rust-lang/rust/issues/44265>`
-    pub fn next(&mut self) -> Option<Result<Packet, ParserError>> {
+    pub fn next(&mut self) -> Option<Result<PacketRef, ParserError>> {
         while self.buf.len() > 0 {
             let pos = match self.find_sync() {
                 Some(x) => x,

--- a/ublox/src/parser.rs
+++ b/ublox/src/parser.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use crate::{
     error::ParserError,
     ubx_packets::{
-        packetref::{match_packet, PacketRef, MAX_PAYLOAD_LEN},
+        packetref::{match_packet, Packet, MAX_PAYLOAD_LEN},
         SYNC_CHAR_1, SYNC_CHAR_2,
     },
 };
@@ -424,7 +424,7 @@ impl<T: UnderlyingBuffer> ParserIter<'_, T> {
         (0..self.buf.len()).find(|&i| self.buf[i] == SYNC_CHAR_1)
     }
 
-    fn extract_packet(&mut self, pack_len: usize) -> Option<Result<PacketRef, ParserError>> {
+    fn extract_packet(&mut self, pack_len: usize) -> Option<Result<Packet, ParserError>> {
         if !self.buf.can_drain_and_take(6, pack_len + 2) {
             if self.buf.potential_lost_bytes() > 0 {
                 // We ran out of space, drop this packet and move on
@@ -468,7 +468,7 @@ impl<T: UnderlyingBuffer> ParserIter<'_, T> {
     #[allow(clippy::should_implement_trait)]
     /// Analog of `core::iter::Iterator::next`, should be switched to
     /// trait implementation after merge of `<https://github.com/rust-lang/rust/issues/44265>`
-    pub fn next(&mut self) -> Option<Result<PacketRef, ParserError>> {
+    pub fn next(&mut self) -> Option<Result<Packet, ParserError>> {
         while self.buf.len() > 0 {
             let pos = match self.find_sync() {
                 Some(x) => x,

--- a/ublox/src/ubx_packets.rs
+++ b/ublox/src/ubx_packets.rs
@@ -93,7 +93,8 @@ pub struct UbxUnknownPacketRef<'a> {
 
 #[derive(Debug, Clone)]
 pub struct UbxUnknownPacketOwned {
-    pub payload: Vec<u8>,
+    pub payload: [u8; packetref::MAX_PAYLOAD_LEN as usize],
+    pub payload_len: usize,
     pub class: u8,
     pub msg_id: u8,
 }

--- a/ublox/src/ubx_packets.rs
+++ b/ublox/src/ubx_packets.rs
@@ -83,10 +83,17 @@ pub trait UbxPacketCreator {
 }
 
 /// Packet not supported yet by this crate
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct UbxUnknownPacketRef<'a> {
     pub payload: &'a [u8],
+    pub class: u8,
+    pub msg_id: u8,
+}
+
+#[derive(Debug, Clone)]
+pub struct UbxUnknownPacketOwned {
+    pub payload: Vec<u8>,
     pub class: u8,
     pub msg_id: u8,
 }

--- a/ublox/src/ubx_packets/cfg_val.rs
+++ b/ublox/src/ubx_packets/cfg_val.rs
@@ -1088,7 +1088,7 @@ cfg_val! {
   SignalGLoL2Ena,        0x1031001a, bool,
 
   /// "Undocumented" L5 Health Bit Ignore (see
-  /// https://content.u-blox.com/sites/default/files/documents/GPS-L5-configuration_AppNote_UBX-21038688.pdf)
+  /// <https://content.u-blox.com/sites/default/files/documents/GPS-L5-configuration_AppNote_UBX-21038688.pdf>)
   UndocumentedL5Enable,  0x10320001, bool,
 
   // CFG-TP-*

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -1355,7 +1355,7 @@ impl CfgItfmConfig {
     }
 
     const fn into_raw(self) -> u32 {
-        (self.enable as u32) << 31
+        ((self.enable as u32) << 31)
             | self.cw_threshold.into_raw()
             | self.bb_threshold.into_raw()
             | self.algorithm_bits.into_raw()

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -26,6 +26,7 @@ use super::{
     SYNC_CHAR_1, SYNC_CHAR_2,
 };
 
+pub use packetref::PacketRef;
 pub mod packetref;
 
 /// Used to help serialize the packet's fields flattened within a struct containing the msg_id and class fields, but

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -26,7 +26,6 @@ use super::{
     SYNC_CHAR_1, SYNC_CHAR_2,
 };
 
-pub use packetref::Packet;
 pub mod packetref;
 
 /// Used to help serialize the packet's fields flattened within a struct containing the msg_id and class fields, but
@@ -3946,6 +3945,20 @@ impl EsfMeas {
 }
 
 impl EsfMeasRef<'_> {
+    fn data_len(&self) -> usize {
+        self.flags().num_meas() as usize * 4
+    }
+
+    fn calib_tag_len(&self) -> usize {
+        if self.flags().calib_tag_valid() {
+            4
+        } else {
+            0
+        }
+    }
+}
+
+impl EsfMeasOwned {
     fn data_len(&self) -> usize {
         self.flags().num_meas() as usize * 4
     }

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -26,7 +26,7 @@ use super::{
     SYNC_CHAR_1, SYNC_CHAR_2,
 };
 
-pub use packetref::PacketRef;
+pub use packetref::Packet;
 pub mod packetref;
 
 /// Used to help serialize the packet's fields flattened within a struct containing the msg_id and class fields, but

--- a/ublox/src/ubx_packets/packets.rs
+++ b/ublox/src/ubx_packets/packets.rs
@@ -4579,7 +4579,7 @@ pub enum EsfSensorType {
     SpeedTick = 10,
     /// Speed in [m/s]
     Speed = 11,
-    /// Temperature Celsius [deg]
+    /// Temperature Celsius \[deg\]
     GyroTemp = 12,
     /// Angular acceleration in [deg/s]
     GyroY = 13,

--- a/ublox/src/ubx_packets/packets/packetref.rs
+++ b/ublox/src/ubx_packets/packets/packetref.rs
@@ -1,11 +1,11 @@
 use super::*;
-use crate::UbxUnknownPacketRef;
+use crate::{UbxUnknownPacketOwned, UbxUnknownPacketRef};
 use ublox_derive::define_recv_packets;
 
 #[cfg(feature = "ubx_proto23")]
 define_recv_packets!(
-    enum PacketRef {
-        _ = UbxUnknownPacketRef,
+    enum Packet {
+        _ = UbxUnknownPacket,
         AlpSrv,
         AckAck,
         AckNak,
@@ -72,8 +72,8 @@ define_recv_packets!(
 
 #[cfg(feature = "ubx_proto27")]
 define_recv_packets!(
-    enum PacketRef {
-        _ = UbxUnknownPacketRef,
+    enum Packet {
+        _ = UbxUnknownPacket,
         AlpSrv,
         AckAck,
         AckNak,
@@ -136,8 +136,8 @@ define_recv_packets!(
 
 #[cfg(feature = "ubx_proto31")]
 define_recv_packets!(
-    enum PacketRef {
-        _ = UbxUnknownPacketRef,
+    enum Packet {
+        _ = UbxUnknownPacket,
         AlpSrv,
         AckAck,
         AckNak,

--- a/ublox/tests/parser_tests.rs
+++ b/ublox/tests/parser_tests.rs
@@ -335,7 +335,7 @@ fn test_ack_ack_to_owned_can_be_moved() {
         Some(Ok(PacketRef::AckAck(ack_packet))) => {
             assert_eq!(ack_packet.class(), expect_ack_payload_class_id);
             let owned = ack_packet.to_owned();
-            assert_eq(
+            assert_eq!(
                 owned,
                 ack_ack,
                 "Owned packet is not the same as borrowed packet",

--- a/ublox/tests/parser_tests.rs
+++ b/ublox/tests/parser_tests.rs
@@ -322,3 +322,22 @@ fn test_double_start_at_end() {
     }
     assert!(it.next().is_none());
 }
+
+#[test]
+fn test_ack_ack_to_owned_can_be_moved() {
+    let ack_ack = [0xb5, 0x62, 0x5, 0x1, 0x2, 0x0, 0x4, 0x5, 0x11, 0x38];
+
+    let mut parser = ublox::Parser::default();
+    let mut it = parser.consume(&ack_ack);
+    match it.next() {
+        Some(Ok(PacketRef::AckAck(ack_packet))) => {
+            assert_eq!(ack_packet.class(), 4); // Why is this 4 ???
+            let owned = ack_packet.to_owned();
+            let thread = std::thread::spawn(move || {
+                std::dbg!(owned);
+            });
+            thread.join().unwrap();
+        },
+        _ => panic!(),
+    };
+}

--- a/ublox/tests/parser_tests.rs
+++ b/ublox/tests/parser_tests.rs
@@ -334,12 +334,11 @@ fn test_ack_ack_to_owned_can_be_moved() {
     match it.next() {
         Some(Ok(PacketRef::AckAck(ack_packet))) => {
             assert_eq!(ack_packet.class(), expect_ack_payload_class_id);
-            let owned = ack_packet.to_owned();
-            assert_eq!(
-                owned,
-                ack_ack,
-                "Owned packet is not the same as borrowed packet",
-            );
+            let borrowed: ublox::AckAckRef = ack_packet;
+            let owned: ublox::AckAckOwned = borrowed.to_owned();
+
+            assert_eq!(borrowed.class(), owned.class());
+            assert_eq!(borrowed.msg_id(), owned.msg_id());
 
             let thread = std::thread::spawn(move || {
                 // This won't compile if the owned packet is not moveable.

--- a/ublox_derive/Cargo.toml
+++ b/ublox_derive/Cargo.toml
@@ -20,3 +20,4 @@ syn = { version = "1.0", features = ["extra-traits", "full"] }
 [dev-dependencies]
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 which = { version = "7.0.2", default-features = false }
+pretty_assertions = "1.4.1"

--- a/ublox_derive/src/output.rs
+++ b/ublox_derive/src/output.rs
@@ -792,13 +792,13 @@ fn generate_fn_match_packet_owned(
             match (class, msg_id) {
                 #(#matches_owned)*
                 _ => {
-                    let mut fixed_payload = [0u8; MAX_PAYLOAD_LEN as usize];
-                    let len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
-                    fixed_payload[..len].copy_from_slice(&payload[..len]);
+                    let mut payload = [0u8; MAX_PAYLOAD_LEN as usize];
+                    let payload_len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
+                    payload[..payload_len].copy_from_slice(&payload[..payload_len]);
 
                     Ok(#union_enum_name_owned::Unknown(#unknown_var_owned {
-                        payload: fixed_payload,
-                        payload_len: len,
+                        payload,
+                        payload_len,
                         class,
                         msg_id
                     }))

--- a/ublox_derive/src/output.rs
+++ b/ublox_derive/src/output.rs
@@ -850,11 +850,17 @@ pub fn generate_code_for_parse(recv_packs: &RecvPackets) -> TokenStream {
         }
     };
 
-    let fn_match_packet =
-        match_packet::generate_fn_match_packet(&union_enum_name_ref, &matches_ref, &unknown_var_ref);
+    let fn_match_packet = match_packet::generate_fn_match_packet(
+        &union_enum_name_ref,
+        &matches_ref,
+        &unknown_var_ref,
+    );
 
-    let fn_match_packet_owned =
-    match_packet::generate_fn_match_packet_owned(&union_enum_name_owned, &matches_owned, &unknown_var_owned);
+    let fn_match_packet_owned = match_packet::generate_fn_match_packet_owned(
+        &union_enum_name_owned,
+        &matches_owned,
+        &unknown_var_owned,
+    );
 
     quote! {
         #[doc = "All possible packets enum"]

--- a/ublox_derive/src/output.rs
+++ b/ublox_derive/src/output.rs
@@ -8,17 +8,34 @@ use quote::{format_ident, quote, ToTokens};
 use std::{collections::HashSet, convert::TryFrom};
 use syn::{parse_quote, Ident, Type};
 
-fn generate_debug_impl(pack_name: &str, ref_name: &Ident, pack_descr: &PackDesc) -> TokenStream {
-    let fields = pack_descr.fields.iter().map(|field| {
-        let field_name = &field.name;
-        let field_accessor = field.intermediate_field_name();
-        quote! {
-            .field(stringify!(#field_name), &self.#field_accessor())
-        }
-    });
+fn generate_debug_impl(
+    pack_name: &str,
+    ref_name: &Ident,
+    owned_name: &Ident,
+    pack_descr: &PackDesc,
+) -> TokenStream {
+    let fields: Vec<TokenStream> = pack_descr
+        .fields
+        .iter()
+        .map(|field| {
+            let field_name = &field.name;
+            let field_accessor = field.intermediate_field_name();
+            quote! {
+                .field(stringify!(#field_name), &self.#field_accessor())
+            }
+        })
+        .collect();
+
     quote! {
         impl core::fmt::Debug for #ref_name<'_> {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.debug_struct(#pack_name)
+                    #(#fields)*
+                    .finish()
+            }
+        }
+        impl core::fmt::Debug for #owned_name {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 f.debug_struct(#pack_name)
                     #(#fields)*
                     .finish()
@@ -77,6 +94,11 @@ fn generate_serialize_impl(
 pub fn generate_recv_code_for_packet(pack_descr: &PackDesc) -> TokenStream {
     let pack_name = &pack_descr.name;
     let ref_name = format_ident!("{}Ref", pack_descr.name);
+    let owned_name = format_ident!("{}Owned", pack_descr.name);
+    let packet_size = match pack_descr.header.payload_len {
+        PayloadLen::Fixed(value) => value,
+        PayloadLen::Max(value) => value,
+    } as usize;
 
     let mut getters = Vec::with_capacity(pack_descr.fields.len());
     let mut field_validators = Vec::new();
@@ -250,7 +272,7 @@ pub fn generate_recv_code_for_packet(pack_descr: &PackDesc) -> TokenStream {
         }
     };
 
-    let debug_impl = generate_debug_impl(pack_name, &ref_name, pack_descr);
+    let debug_impl = generate_debug_impl(pack_name, &ref_name, &owned_name, pack_descr);
     let serialize_impl = generate_serialize_impl(pack_name, &ref_name, pack_descr);
 
     quote! {
@@ -263,9 +285,44 @@ pub fn generate_recv_code_for_packet(pack_descr: &PackDesc) -> TokenStream {
                 self.0
             }
 
+            pub fn to_owned(&self) -> #owned_name {
+                self.into()
+            }
+
             #(#getters)*
 
             #validator
+        }
+
+        #[doc = #struct_comment]
+        #[doc = "Owns the underlying buffer of data, contains accessor methods to retrieve data."]
+        pub struct #owned_name([u8; #packet_size]);
+
+        impl #owned_name {
+            const PACKET_SIZE: usize = #packet_size;
+
+            #[inline]
+            pub fn as_bytes(&self) -> &[u8] {
+                &self.0
+            }
+
+            #(#getters)*
+
+            #validator
+        }
+
+        impl<'a> From<&#ref_name<'a>> for #owned_name {
+            fn from(packet: &#ref_name<'a>) -> Self {
+                let mut bytes = [0u8; #packet_size];
+                bytes.clone_from_slice(packet.as_bytes());
+                Self(bytes)
+            }
+        }
+
+        impl<'a> From<#ref_name<'a>> for #owned_name {
+            fn from(packet: #ref_name<'a>) -> Self {
+                (&packet).into()
+            }
         }
 
         #debug_impl
@@ -707,31 +764,57 @@ pub fn generate_code_to_extend_bitflags(bitflags: BitFlagsMacro) -> syn::Result<
 }
 
 pub fn generate_code_for_parse(recv_packs: &RecvPackets) -> TokenStream {
-    let union_enum_name = &recv_packs.union_enum_name;
+    let union_enum_name_ref = format_ident!("{}Ref", &recv_packs.union_enum_name);
+    let union_enum_name_owned = format_ident!("{}Owned", &recv_packs.union_enum_name);
 
-    let mut pack_enum_variants = Vec::with_capacity(recv_packs.all_packets.len());
-    let mut matches = Vec::with_capacity(recv_packs.all_packets.len());
-    let mut class_id_matches = Vec::with_capacity(recv_packs.all_packets.len());
+    let mut pack_enum_variants_ref = Vec::with_capacity(recv_packs.all_packets.len());
+    let mut pack_enum_variants_owned = Vec::with_capacity(recv_packs.all_packets.len());
+
+    let mut matches_ref = Vec::with_capacity(recv_packs.all_packets.len());
+    let mut matches_owned = Vec::with_capacity(recv_packs.all_packets.len());
+    let mut matches_ref_to_owned = Vec::with_capacity(recv_packs.all_packets.len());
+
+    let mut class_id_matches_ref = Vec::with_capacity(recv_packs.all_packets.len());
+    let mut class_id_matches_owned = Vec::with_capacity(recv_packs.all_packets.len());
+
     let mut serializers = Vec::with_capacity(recv_packs.all_packets.len());
 
     for name in &recv_packs.all_packets {
         let ref_name = format_ident!("{}Ref", name);
-        pack_enum_variants.push(quote! {
+        let owned_name = format_ident!("{}Owned", name);
+        pack_enum_variants_ref.push(quote! {
             #name(#ref_name <'a>)
         });
+        pack_enum_variants_owned.push(quote! {
+            #name(#owned_name)
+        });
 
-        matches.push(quote! {
+        matches_ref.push(quote! {
             (#name::CLASS, #name::ID) if <#ref_name>::validate(payload).is_ok()  => {
-                Ok(#union_enum_name::#name(#ref_name(payload)))
+                Ok(#union_enum_name_ref::#name(#ref_name(payload)))
             }
         });
 
-        class_id_matches.push(quote! {
-            #union_enum_name::#name(_) => (#name::CLASS, #name::ID)
+        matches_owned.push(quote! {
+            (#name::CLASS, #name::ID) if <#owned_name>::validate(payload).is_ok()  => {
+                let mut bytes = [0u8; #owned_name::PACKET_SIZE];
+                bytes.clone_from_slice(payload);
+                Ok(#union_enum_name_owned::#name(#owned_name(bytes)))
+            }
+        });
+        matches_ref_to_owned.push(quote! {
+            #union_enum_name_ref::#name(packet) => #union_enum_name_owned::#name(packet.into()),
+        });
+
+        class_id_matches_ref.push(quote! {
+            #union_enum_name_ref::#name(_) => (#name::CLASS, #name::ID)
+        });
+        class_id_matches_owned.push(quote! {
+            #union_enum_name_owned::#name(_) => (#name::CLASS, #name::ID)
         });
 
         serializers.push(quote! {
-            #union_enum_name::#name(ref msg) => PacketSerializer {
+            #union_enum_name_ref::#name(ref msg) => PacketSerializer {
                 class: #name::CLASS,
                 msg_id: #name::ID,
                 msg,
@@ -740,7 +823,8 @@ pub fn generate_code_for_parse(recv_packs: &RecvPackets) -> TokenStream {
         });
     }
 
-    let unknown_var = &recv_packs.unknown_ty;
+    let unknown_var_ref = format_ident!("{}Ref", &recv_packs.unknown_ty);
+    let unknown_var_owned = format_ident!("{}Owned", &recv_packs.unknown_ty);
 
     let max_payload_len_calc = recv_packs
         .all_packets
@@ -752,28 +836,67 @@ pub fn generate_code_for_parse(recv_packs: &RecvPackets) -> TokenStream {
     quote! {
         #[doc = "All possible packets enum"]
         #[derive(Debug)]
-        pub enum #union_enum_name<'a> {
-            #(#pack_enum_variants),*,
-            Unknown(#unknown_var<'a>)
+        pub enum #union_enum_name_ref<'a> {
+            #(#pack_enum_variants_ref),*,
+            Unknown(#unknown_var_ref<'a>)
+        }
+        #[doc = "All possible packets enum, owning the underlying data"]
+        #[derive(Debug)]
+        pub enum #union_enum_name_owned {
+            #(#pack_enum_variants_owned),*,
+            Unknown(#unknown_var_owned)
         }
 
-        impl<'a> #union_enum_name<'a> {
+        impl<'a> #union_enum_name_ref<'a> {
             pub fn class_and_msg_id(&self) -> (u8, u8) {
                 match *self {
-                    #(#class_id_matches),*,
-                    #union_enum_name::Unknown(ref pack) => (pack.class, pack.msg_id),
+                    #(#class_id_matches_ref),*,
+                    #union_enum_name_ref::Unknown(ref pack) => (pack.class, pack.msg_id),
+                }
+            }
+
+            pub fn to_owned(&self) -> #union_enum_name_owned {
+                self.into()
+            }
+        }
+        impl #union_enum_name_owned {
+            pub fn class_and_msg_id(&self) -> (u8, u8) {
+                match *self {
+                    #(#class_id_matches_owned),*,
+                    #union_enum_name_owned::Unknown(ref pack) => (pack.class, pack.msg_id),
                 }
             }
         }
 
-        pub(crate) fn match_packet(class: u8, msg_id: u8, payload: &[u8]) -> Result<#union_enum_name, ParserError> {
+        pub(crate) fn match_packet(class: u8, msg_id: u8, payload: &[u8]) -> Result<#union_enum_name_ref, ParserError> {
             match (class, msg_id) {
-                #(#matches)*
-                _ => Ok(#union_enum_name::Unknown(#unknown_var {
+                #(#matches_ref)*
+                _ => Ok(#union_enum_name_ref::Unknown(#unknown_var_ref {
                     payload,
                     class,
                     msg_id
                 })),
+            }
+        }
+        pub(crate) fn match_packet_owned(class: u8, msg_id: u8, payload: &[u8]) -> Result<#union_enum_name_owned, ParserError> {
+            match (class, msg_id) {
+                #(#matches_owned)*
+                _ => Ok(#union_enum_name_owned::Unknown(#unknown_var_owned {
+                    payload: payload.into(),
+                    class,
+                    msg_id
+                })),
+            }
+        }
+
+        impl<'a> From<&#union_enum_name_ref<'a>> for #union_enum_name_owned {
+            fn from(packet: &#union_enum_name_ref<'a>) -> Self {
+                match packet {
+                    #(#matches_ref_to_owned)*
+                    #union_enum_name_ref::Unknown(#unknown_var_ref {payload, class, msg_id}) => {
+                        PacketOwned::Unknown(#unknown_var_owned { payload: payload.to_vec(), class: *class, msg_id: *msg_id })
+                    },
+                }
             }
         }
 
@@ -803,14 +926,14 @@ pub fn generate_code_for_parse(recv_packs: &RecvPackets) -> TokenStream {
         }
 
         #[cfg(feature = "serde")]
-        impl serde::Serialize for #union_enum_name<'_> {
+        impl serde::Serialize for #union_enum_name_ref<'_> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
             {
                 match *self {
                     #(#serializers),*,
-                    #union_enum_name::Unknown(ref pack) => pack.serialize(serializer),
+                    #union_enum_name_ref::Unknown(ref pack) => pack.serialize(serializer),
                 }
             }
         }

--- a/ublox_derive/src/output.rs
+++ b/ublox_derive/src/output.rs
@@ -837,13 +837,13 @@ pub fn generate_code_for_parse(recv_packs: &RecvPackets) -> TokenStream {
 
     let unknown_conversion = quote! {
         #union_enum_name_ref::Unknown(#unknown_var_ref {payload, class, msg_id}) => {
-            let mut fixed_payload = [0u8; MAX_PAYLOAD_LEN as usize];
-            let len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
-            fixed_payload[..len].copy_from_slice(&payload[..len]);
+            let mut payload_copy = [0u8; MAX_PAYLOAD_LEN as usize];
+            let payload_len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
+            payload_copy[..payload_len].copy_from_slice(&payload[..payload_len]);
 
             #union_enum_name_owned::Unknown(#unknown_var_owned {
-                payload: fixed_payload,
-                payload_len: len,
+                payload: payload_copy,
+                payload_len,
                 class: *class,
                 msg_id: *msg_id
             })

--- a/ublox_derive/src/output/match_packet.rs
+++ b/ublox_derive/src/output/match_packet.rs
@@ -33,12 +33,12 @@ pub(super) fn generate_fn_match_packet_owned(
             match (class, msg_id) {
                 #(#matches_owned)*
                 _ => {
-                    let mut copied_payload = [0u8; MAX_PAYLOAD_LEN as usize];
+                    let mut payload_copy = [0u8; MAX_PAYLOAD_LEN as usize];
                     let payload_len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
-                    copied_payload[..payload_len].copy_from_slice(&payload[..payload_len]);
+                    payload_copy[..payload_len].copy_from_slice(&payload[..payload_len]);
 
                     Ok(#union_enum_name_owned::Unknown(#unknown_var_owned {
-                        payload: copied_payload,
+                        payload: payload_copy,
                         payload_len,
                         class,
                         msg_id

--- a/ublox_derive/src/output/match_packet.rs
+++ b/ublox_derive/src/output/match_packet.rs
@@ -1,0 +1,50 @@
+//! Code generation for the `match_packet` functions
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Ident;
+
+pub(super) fn generate_fn_match_packet(
+    union_enum_name_ref: &Ident,
+    matches_ref: &[TokenStream],
+    unknown_var_ref: &Ident,
+) -> TokenStream {
+    quote! {
+        pub(crate) fn match_packet(class: u8, msg_id: u8, payload: &[u8]) -> Result<#union_enum_name_ref, ParserError> {
+            match (class, msg_id) {
+                #(#matches_ref)*
+                _ => Ok(#union_enum_name_ref::Unknown(#unknown_var_ref {
+                    payload,
+                    class,
+                    msg_id
+                })),
+            }
+        }
+    }
+}
+
+pub(super) fn generate_fn_match_packet_owned(
+    union_enum_name_owned: &Ident,
+    matches_owned: &[TokenStream],
+    unknown_var_owned: &Ident,
+) -> TokenStream {
+    quote! {
+        pub(crate) fn match_packet_owned(class: u8, msg_id: u8, payload: &[u8]) -> Result<#union_enum_name_owned, ParserError> {
+            match (class, msg_id) {
+                #(#matches_owned)*
+                _ => {
+                    let mut payload = [0u8; MAX_PAYLOAD_LEN as usize];
+                    let payload_len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
+                    payload[..payload_len].copy_from_slice(&payload[..payload_len]);
+
+                    Ok(#union_enum_name_owned::Unknown(#unknown_var_owned {
+                        payload,
+                        payload_len,
+                        class,
+                        msg_id
+                    }))
+                }
+            }
+        }
+    }
+}

--- a/ublox_derive/src/output/match_packet.rs
+++ b/ublox_derive/src/output/match_packet.rs
@@ -33,12 +33,12 @@ pub(super) fn generate_fn_match_packet_owned(
             match (class, msg_id) {
                 #(#matches_owned)*
                 _ => {
-                    let mut payload = [0u8; MAX_PAYLOAD_LEN as usize];
+                    let mut copied_payload = [0u8; MAX_PAYLOAD_LEN as usize];
                     let payload_len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
-                    payload[..payload_len].copy_from_slice(&payload[..payload_len]);
+                    copied_payload[..payload_len].copy_from_slice(&payload[..payload_len]);
 
                     Ok(#union_enum_name_owned::Unknown(#unknown_var_owned {
-                        payload,
+                        payload: copied_payload,
                         payload_len,
                         class,
                         msg_id

--- a/ublox_derive/src/tests.rs
+++ b/ublox_derive/src/tests.rs
@@ -794,11 +794,11 @@ fn test_define_recv_packets() {
                         Ok(PacketOwned::Pack2(Pack2Owned(bytes)))
                     },
                     _ => {
-                        let mut copied_payload = [0u8; MAX_PAYLOAD_LEN as usize];
+                        let mut payload_copy = [0u8; MAX_PAYLOAD_LEN as usize];
                         let payload_len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
-                        copied_payload[..payload_len].copy_from_slice(&payload[..payload_len]);
+                        payload_copy[..payload_len].copy_from_slice(&payload[..payload_len]);
                         Ok(PacketOwned::Unknown(UnknownPacketOwned {
-                            payload: copied_payload,
+                            payload: payload_copy,
                             payload_len,
                             class,
                             msg_id,
@@ -816,12 +816,12 @@ fn test_define_recv_packets() {
                             class,
                             msg_id,
                         }) => {
-                            let mut fixed_payload = [0u8; MAX_PAYLOAD_LEN as usize];
-                            let len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
-                            fixed_payload[..len].copy_from_slice(&payload[..len]);
+                            let mut payload_copy = [0u8; MAX_PAYLOAD_LEN as usize];
+                            let payload_len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
+                            payload_copy[..payload_len].copy_from_slice(&payload[..payload_len]);
                             PacketOwned::Unknown(UnknownPacketOwned {
-                                payload: fixed_payload,
-                                payload_len: len,
+                                payload: payload_copy,
+                                payload_len,
                                 class: *class,
                                 msg_id: *msg_id,
                             })

--- a/ublox_derive/src/tests.rs
+++ b/ublox_derive/src/tests.rs
@@ -793,11 +793,17 @@ fn test_define_recv_packets() {
                         bytes.clone_from_slice(payload);
                         Ok(PacketOwned::Pack2(Pack2Owned(bytes)))
                     },
-                    _ => Ok(PacketOwned::Unknown(UnknownPacketOwned {
-                        payload: payload.into(),
-                        class,
-                        msg_id,
-                    })),
+                    _ => {
+                        let mut fixed_payload = [0u8; MAX_PAYLOAD_LEN as usize];
+                        let len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
+                        fixed_payload[..len].copy_from_slice(&payload[..len]);
+                        Ok(PacketOwned::Unknown(UnknownPacketOwned {
+                            payload: fixed_payload,
+                            payload_len: len,
+                            class,
+                            msg_id,
+                        }))
+                    },
                 }
             }
             impl<'a> From<&PacketRef<'a>> for PacketOwned {
@@ -809,11 +815,17 @@ fn test_define_recv_packets() {
                             payload,
                             class,
                             msg_id,
-                        }) => PacketOwned::Unknown(UnknownPacketOwned {
-                            payload: payload.to_vec(),
-                            class: *class,
-                            msg_id: *msg_id,
-                        }),
+                        }) => {
+                            let mut fixed_payload = [0u8; MAX_PAYLOAD_LEN as usize];
+                            let len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
+                            fixed_payload[..len].copy_from_slice(&payload[..len]);
+                            PacketOwned::Unknown(UnknownPacketOwned {
+                                payload: fixed_payload,
+                                payload_len: len,
+                                class: *class,
+                                msg_id: *msg_id,
+                            })
+                        },
                     }
                 }
             }

--- a/ublox_derive/src/tests.rs
+++ b/ublox_derive/src/tests.rs
@@ -794,11 +794,11 @@ fn test_define_recv_packets() {
                         Ok(PacketOwned::Pack2(Pack2Owned(bytes)))
                     },
                     _ => {
-                        let mut payload = [0u8; MAX_PAYLOAD_LEN as usize];
+                        let mut copied_payload = [0u8; MAX_PAYLOAD_LEN as usize];
                         let payload_len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
-                        payload[..payload_len].copy_from_slice(&payload[..payload_len]);
+                        copied_payload[..payload_len].copy_from_slice(&payload[..payload_len]);
                         Ok(PacketOwned::Unknown(UnknownPacketOwned {
-                            payload,
+                            payload: copied_payload,
                             payload_len,
                             class,
                             msg_id,

--- a/ublox_derive/src/tests.rs
+++ b/ublox_derive/src/tests.rs
@@ -794,12 +794,12 @@ fn test_define_recv_packets() {
                         Ok(PacketOwned::Pack2(Pack2Owned(bytes)))
                     },
                     _ => {
-                        let mut fixed_payload = [0u8; MAX_PAYLOAD_LEN as usize];
-                        let len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
-                        fixed_payload[..len].copy_from_slice(&payload[..len]);
+                        let mut payload = [0u8; MAX_PAYLOAD_LEN as usize];
+                        let payload_len = core::cmp::min(payload.len(), MAX_PAYLOAD_LEN as usize);
+                        payload[..payload_len].copy_from_slice(&payload[..payload_len]);
                         Ok(PacketOwned::Unknown(UnknownPacketOwned {
-                            payload: fixed_payload,
-                            payload_len: len,
+                            payload,
+                            payload_len,
                             class,
                             msg_id,
                         }))

--- a/ublox_derive/src/types.rs
+++ b/ublox_derive/src/types.rs
@@ -50,6 +50,7 @@ pub enum PayloadLen {
 }
 
 impl PayloadLen {
+    /// If the payload length is fixed, returns `Some(len)` else `None`
     pub fn fixed(&self) -> Option<u16> {
         if let PayloadLen::Fixed(len) = self {
             Some(*len)


### PR DESCRIPTION
Credit to @maximeborges
Port of their PR https://github.com/ublox-rs/ublox/pull/44. Port because it wasn't feasible to rebase it on current master.

Key change from initial PR is:

- Remove `Vec<u8>` from `UbxUnknownPacketOwned` and instead use a fixed size array to avoid having to hide it behind the `alloc` feature. Not even sure how that could work at all.

Additionally I added `pretty_assertions` to `ublox_derive` dev-dependencies, makes it much easier to diff macro output in tests.

Needs:

- [x] Example
- [x] Tests
- [x] Changelog