### PR TITLE
add link checker workflow

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -1,0 +1,35 @@
+name: Check Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    # Runs every Thursday at 20:24 GMT to avoid bit rot
+    - cron: "24 20 * * 4"
+  pull_request:
+    paths:
+      - ".github/workflows/check_links.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v4
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-<div style="text-align: right;">Table of Contents↗️</div>
+<div align=right>Table of Contents↗️</div>
 
-<h1 style="text-align: center;">uBlox for Rust
+<h1 align=center>uBlox for Rust
 
 <code>ublox</code>
 </h1>
 
-<div style="text-align: center;">
+<div align="center">
     <a href=https://crates.io/crates/ublox>
         <img src=https://img.shields.io/crates/v/ublox.svg alt="crates.io version">
     </a>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-<div align=right>Table of Contents↗️</div>
+<div style="text-align: right;">Table of Contents↗️</div>
 
-<h1 align=center>uBlox for Rust
+<h1 style="text-align: center;">uBlox for Rust
 
 <code>ublox</code>
 </h1>
 
-<div align="center">
+<div style="text-align: center;">
     <a href=https://crates.io/crates/ublox>
         <img src=https://img.shields.io/crates/v/ublox.svg alt="crates.io version">
     </a>
@@ -15,7 +15,7 @@
     <a href=https://docs.rs/ublox/badge.svg>
         <img src=https://docs.rs/ublox/badge.svg alt="docs status">
     </a>
-    <a href=https://github.com/lkolbly/ublox/blob/master/LICENSE.md>
+    <a href=https://github.com/ublox-rs/ublox/tree/master/LICENSE>
         <img src=https://img.shields.io/badge/license-MIT-blue.svg alt="MIT License">
     </a>
     <a href=https://www.whatrustisit.com>


### PR DESCRIPTION
Resolves #115 

We only had one broken link ⭐ 

Also I discovered that HTML attributes are deprecated, but I reverted replacing them with inline CSS because github's markdown renderer doesn't support it. The one in RustRover renders it perfectly so I assumed GitHub would too, oh well.