### PR TITLE
Port extraction of RTCM packets from buffer (PR #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ See the documentation for the individual `Builder` structs for information on th
 
 ## Parsing Packets
 
-Parsing packets happens by instantiating a `Parser` object and then adding data into it using its `consume()` method. The parser contains an internal buffer of data, and when `consume()` is called that data is copied into the internal buffer and an iterator-like object is returned to access the packets. For example:
+Parsing packets happens by instantiating a `Parser` object and then adding data into it using its `consume_ubx()` method. The parser contains an internal buffer of data, and when `consume_ubx()` is called that data is copied into the internal buffer and an iterator-like object is returned to access the packets. For example:
 
 ```rust
 # #[cfg(any(feature = "alloc", feature = "std"))] {
     use ublox::Parser;
     let mut parser = Parser::default();
     let my_raw_data = vec![1, 2, 3, 4]; // From your serial port
-    let mut it = parser.consume(&my_raw_data);
+    let mut it = parser.consume_ubx(&my_raw_data);
     loop {
         match it.next() {
             Some(Ok(packet)) => {

--- a/examples/ublox-device/src/lib.rs
+++ b/examples/ublox-device/src/lib.rs
@@ -72,9 +72,9 @@ impl Device {
                 break;
             }
 
-            // parser.consume adds the buffer to its internal buffer, and
+            // parser.consume_ubx adds the buffer to its internal buffer, and
             // returns an iterator-like object we can use to process the packets
-            let mut it = self.parser.consume(&local_buf[..nbytes]);
+            let mut it = self.parser.consume_ubx(&local_buf[..nbytes]);
             loop {
                 match it.next() {
                     Some(Ok(packet)) => {

--- a/ublox/benches/packet_benchmark.rs
+++ b/ublox/benches/packet_benchmark.rs
@@ -26,7 +26,7 @@ fn profiled() -> Criterion {
 fn parse_all<T: UnderlyingBuffer>(mut parser: Parser<T>, data: &[u8], chunk_size: usize) -> usize {
     let mut count = 0;
     for chunk in data.chunks(chunk_size) {
-        let mut it = parser.consume(chunk);
+        let mut it = parser.consume_ubx(chunk);
         loop {
             match it.next() {
                 Some(Ok(_packet)) => {

--- a/ublox/src/lib.rs
+++ b/ublox/src/lib.rs
@@ -9,7 +9,8 @@ extern crate serde;
 
 pub use crate::{
     error::{DateTimeError, MemWriterError, ParserError},
-    parser::{FixedLinearBuffer, Parser, ParserIter, UnderlyingBuffer},
+    parser::{FixedLinearBuffer, Parser, UbxParserIter, UnderlyingBuffer},
+    parser::{AnyPacketRef, RtcmPacketRef},
     ubx_packets::*,
 };
 

--- a/ublox/src/lib.rs
+++ b/ublox/src/lib.rs
@@ -9,8 +9,9 @@ extern crate serde;
 
 pub use crate::{
     error::{DateTimeError, MemWriterError, ParserError},
-    parser::{FixedLinearBuffer, Parser, UbxParserIter, UnderlyingBuffer},
-    parser::{AnyPacketRef, RtcmPacketRef},
+    parser::{
+        AnyPacketRef, FixedLinearBuffer, Parser, RtcmPacketRef, UbxParserIter, UnderlyingBuffer,
+    },
     ubx_packets::*,
 };
 

--- a/ublox/src/parser.rs
+++ b/ublox/src/parser.rs
@@ -9,6 +9,8 @@ use crate::{
     },
 };
 
+pub(crate) const RTCM_SYNC_CHAR: u8 = 0xd3;
+
 /// This trait represents an underlying buffer used for the Parser. We provide
 /// implementations for `Vec<u8>` and for `FixedLinearBuffer`, if you want to
 /// use your own struct as an underlying buffer you can implement this trait.
@@ -191,7 +193,7 @@ impl<T: UnderlyingBuffer> Parser<T> {
         self.buf.len()
     }
 
-    pub fn consume<'a>(&'a mut self, new_data: &'a [u8]) -> ParserIter<'a, T> {
+    pub fn consume_ubx<'a>(&'a mut self, new_data: &'a [u8]) -> UbxParserIter<'a, T> {
         let mut buf = DualBuffer::new(&mut self.buf, new_data);
 
         for i in 0..buf.len() {
@@ -201,7 +203,21 @@ impl<T: UnderlyingBuffer> Parser<T> {
             }
         }
 
-        ParserIter { buf }
+        UbxParserIter { buf }
+    }
+
+    pub fn consume_ubx_rtcm<'a>(&'a mut self, new_data: &'a [u8]) -> UbxRtcmParserIter<'a, T> {
+        let mut buf = DualBuffer::new(&mut self.buf, new_data);
+
+        for i in 0..buf.len() {
+
+            if buf[i] == SYNC_CHAR_1 || buf[i] == RTCM_SYNC_CHAR {
+                buf.drain(i);
+                break;
+            }
+        }
+
+        UbxRtcmParserIter { buf }
     }
 }
 
@@ -415,18 +431,13 @@ impl UbxChecksumCalc {
 }
 
 /// Iterator over data stored in `Parser` buffer
-pub struct ParserIter<'a, T: UnderlyingBuffer> {
+pub struct UbxParserIter<'a, T: UnderlyingBuffer> {
     buf: DualBuffer<'a, T>,
 }
 
-impl<T: UnderlyingBuffer> ParserIter<'_, T> {
-    fn find_sync(&self) -> Option<usize> {
-        (0..self.buf.len()).find(|&i| self.buf[i] == SYNC_CHAR_1)
-    }
-
-    fn extract_packet(&mut self, pack_len: usize) -> Option<Result<PacketRef, ParserError>> {
-        if !self.buf.can_drain_and_take(6, pack_len + 2) {
-            if self.buf.potential_lost_bytes() > 0 {
+fn extract_packet_ubx<'a, 'b, T: UnderlyingBuffer>(buf : &'b mut DualBuffer<'a, T>, pack_len: usize) -> Option<Result<PacketRef<'b>, ParserError>> {
+    if !buf.can_drain_and_take(6, pack_len + 2) {
+        if buf.potential_lost_bytes() > 0 {
                 // We ran out of space, drop this packet and move on
                 self.buf.drain(2);
                 return Some(Err(ParserError::OutOfMemory {
@@ -456,13 +467,23 @@ impl<T: UnderlyingBuffer> ParserIter<'_, T> {
             Ok(x) => x,
             Err(e) => {
                 return Some(Err(e));
-            },
+            }
         };
         return Some(match_packet(
             class_id,
             msg_id,
             &msg_data[..msg_data.len() - 2], // Exclude the checksum
         ));
+}
+
+impl<'a, T: UnderlyingBuffer> UbxParserIter<'a, T> {
+    fn find_sync(&self) -> Option<usize> {
+        for i in 0..self.buf.len() {
+            if self.buf[i] == SYNC_CHAR_1 {
+                return Some(i);
+            }
+        }
+        None
     }
 
     #[allow(clippy::should_implement_trait)]
@@ -496,7 +517,119 @@ impl<T: UnderlyingBuffer> ParserIter<'_, T> {
                 self.buf.drain(2);
                 continue;
             }
-            return self.extract_packet(pack_len);
+            return extract_packet_ubx(&mut self.buf, pack_len);
+        }
+        None
+    }
+}
+
+/// Iterator over data stored in `Parser` buffer
+pub struct UbxRtcmParserIter<'a, T: UnderlyingBuffer> {
+    buf: DualBuffer<'a, T>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum NextSync {
+    Ubx(usize),
+    Rtcm(usize),
+    None,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct RtcmPacketRef<'a> {
+    pub data : &'a [u8],
+}
+
+#[derive(Debug)]
+pub enum AnyPacketRef<'a> {
+    Ubx(PacketRef<'a>),
+    Rtcm(RtcmPacketRef<'a>),
+}
+
+fn extract_packet_rtcm<'a, 'b, T: UnderlyingBuffer>(buf : &'b mut DualBuffer<'a, T>, pack_len: usize) -> Option<Result<AnyPacketRef<'b>, ParserError>> {
+    if !buf.can_drain_and_take(0, pack_len + 3) {
+        if buf.potential_lost_bytes() > 0 {
+            // We ran out of space, drop this packet and move on
+            // TODO: shouldn't we drain pack_len + 3?
+            buf.drain(2);
+            return Some(Err(ParserError::OutOfMemory {
+                required_size: pack_len + 2,
+            }));
+        }
+        return None;
+    }
+
+    let maybe_data = buf.take(pack_len + 3);
+    match maybe_data {
+        Ok(data) => Some(Ok(AnyPacketRef::Rtcm(RtcmPacketRef::<'b> {data: data}))),
+        Err(e) => Some(Err(e)),
+    }
+}
+
+impl<'a, T: UnderlyingBuffer> UbxRtcmParserIter<'a, T> {
+    fn find_sync(&self) -> NextSync {
+        for i in 0..self.buf.len() {
+            if self.buf[i] == SYNC_CHAR_1 {
+                return NextSync::Ubx(i);
+            }
+            if self.buf[i] == RTCM_SYNC_CHAR {
+                return NextSync::Rtcm(i);
+            }
+        }
+        NextSync::None
+    }
+
+
+    #[allow(clippy::should_implement_trait)]
+    /// Analog of `core::iter::Iterator::next`, should be switched to
+    /// trait implementation after merge of https://github.com/rust-lang/rust/issues/44265
+    pub fn next<'b>(&'b mut self) -> Option<Result<AnyPacketRef<'b>, ParserError>> {
+        while self.buf.len() > 0 {
+            match self.find_sync() {
+                NextSync::Ubx(pos) => {
+                    self.buf.drain(pos);
+
+                    if self.buf.len() < 2 {
+                        return None;
+                    }
+                    if self.buf[1] != SYNC_CHAR_2 {
+                        self.buf.drain(1);
+                        continue;
+                    }
+
+                    if self.buf.len() < 6 {
+                        return None;
+                    }
+
+                    let pack_len: usize = u16::from_le_bytes([self.buf[4], self.buf[5]]).into();
+                    if pack_len > usize::from(MAX_PAYLOAD_LEN) {
+                        self.buf.drain(2);
+                        continue;
+                    }
+                    let maybe_packet = extract_packet_ubx(&mut self.buf, pack_len);
+                    match maybe_packet {
+                        Some(Ok(packet)) => return Some(Ok(AnyPacketRef::Ubx(packet))),
+                        Some(Err(e)) => return Some(Err(e)),
+                        None => return None,
+                    }
+                },
+                NextSync::Rtcm(pos) => {
+                    self.buf.drain(pos);
+
+                    // need to read 3 bytes total for sync char (1) + length (2)
+                    if self.buf.len() < 3 {
+                        return None;
+                    }
+                    // next 2 bytes contain 6 bits reserved + 10 bits length, big endian
+                    let pack_len: usize = (u16::from_be_bytes([self.buf[1], self.buf[2]]) & 0x03ff).into();
+
+                    return extract_packet_rtcm(&mut self.buf, pack_len);
+                }
+                NextSync::None => {
+                    self.buf.clear();
+                    return None;
+                }
+            };
         }
         None
     }
@@ -780,7 +913,7 @@ mod test {
         let bytes = [0xb5, 0xb5, 0x62, 0x5, 0x1, 0x2, 0x0, 0x4, 0x5, 0x11, 0x38];
 
         {
-            let mut it = parser.consume(&bytes);
+            let mut it = parser.consume_ubx(&bytes);
             assert!(matches!(it.next(), Some(Ok(PacketRef::AckAck(_)))));
             assert!(it.next().is_none());
         }
@@ -814,12 +947,12 @@ mod test {
         let mut parser = Parser::new(buffer);
 
         {
-            let mut it = parser.consume(&bytes[0..8]);
+            let mut it = parser.consume_ubx(&bytes[0..8]);
             assert!(it.next().is_none());
         }
 
         {
-            let mut it = parser.consume(&bytes[8..]);
+            let mut it = parser.consume_ubx(&bytes[8..]);
             assert!(
                 matches!(it.next(), Some(Err(ParserError::OutOfMemory { required_size })) if required_size == bytes.len() - 6)
             );
@@ -830,7 +963,7 @@ mod test {
         let bytes = [0xb5, 0x62, 0x5, 0x1, 0x2, 0x0, 0x4, 0x5, 0x11, 0x38];
 
         {
-            let mut it = parser.consume(&bytes);
+            let mut it = parser.consume_ubx(&bytes);
             assert!(matches!(it.next(), Some(Ok(PacketRef::AckAck(_)))));
             assert!(it.next().is_none());
         }
@@ -862,7 +995,7 @@ mod test {
         let mut buffer = [0; 1024];
         let buffer = FixedLinearBuffer::new(&mut buffer);
         let mut parser = Parser::new(buffer);
-        let mut it = parser.consume(&bytes);
+        let mut it = parser.consume_ubx(&bytes);
         assert!(matches!(it.next(), Some(Ok(PacketRef::CfgNav5(_)))));
         assert!(it.next().is_none());
     }
@@ -892,7 +1025,7 @@ mod test {
         .into_packet_bytes();
 
         let mut parser = Parser::default();
-        let mut it = parser.consume(&bytes);
+        let mut it = parser.consume_ubx(&bytes);
         assert!(matches!(it.next(), Some(Ok(PacketRef::CfgNav5(_)))));
         assert!(it.next().is_none());
     }
@@ -917,7 +1050,7 @@ mod test {
         );
 
         let mut parser = Parser::default();
-        let mut it = parser.consume(&data);
+        let mut it = parser.consume_ubx(&data);
         match it.next() {
             Some(Ok(PacketRef::CfgNav5(packet))) => {
                 // We're good

--- a/ublox/src/ubx_packets.rs
+++ b/ublox/src/ubx_packets.rs
@@ -16,6 +16,7 @@ pub trait UbxPacketMeta {
 
 pub(crate) const SYNC_CHAR_1: u8 = 0xb5;
 pub(crate) const SYNC_CHAR_2: u8 = 0x62;
+pub(crate) const RTCM_SYNC_CHAR: u8 = 0xd3;
 
 /// The checksum is calculated over the packet, starting and including
 /// the CLASS field, up until, but excluding, the checksum field.

--- a/ublox/tests/parser_binary_dump_test.rs
+++ b/ublox/tests/parser_binary_dump_test.rs
@@ -58,7 +58,7 @@ fn test_parse_big_dump() {
     for chunk_size in &read_sizes {
         let (buf, rest) = log.split_at(*chunk_size);
         log = rest;
-        let mut it = parser.consume(buf);
+        let mut it = parser.consume_ubx(buf);
         while let Some(pack) = it.next() {
             match pack {
                 Ok(pack) => match pack {


### PR DESCRIPTION
Port this commit [835f44e](https://github.com/ublox-rs/ublox/pull/56/commits/835f44e821b8a4c73d155e365ce52cd363482ca0) from https://github.com/ublox-rs/ublox/pull/56

This implementation allows for extracting RTCM packets from the captured data by this crate.

It also completes the porting of #56  as any other packet additions were added in the meantime since the creation of that PR. 