### PR TITLE
simplify features set usage for the examples

### DIFF
--- a/examples/basic-cli/Cargo.toml
+++ b/examples/basic-cli/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+description = "Demonstrate basic usage of uBlox package"
 authors = [
     "Lane Kolbly <lane@rscheme.org>",
     "Andrei Gherghescu <andrei-ng@protonmail.com>",
@@ -11,15 +12,13 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["alloc", "ubx_proto23"]
-alloc = ["ublox/alloc"]
-ubx_proto23 = ["ublox/ubx_proto23", "ublox_device/ubx_proto23"]
-ubx_proto27 = ["ublox/ubx_proto27", "ublox_device/ubx_proto27"]
-ubx_proto31 = ["ublox/ubx_proto31", "ublox_device/ubx_proto31"]
+default = ["ubx_proto23"]
+ubx_proto23 = ["ublox_device/ubx_proto23"]
+ubx_proto27 = ["ublox_device/ubx_proto27"]
+ubx_proto31 = ["ublox_device/ubx_proto31"]
 
 [dependencies]
 chrono = "0.4"
 clap = { version = "4.2", features = ["cargo"] }
 
-ublox = { path = "../../ublox", default-features = false, optional = true }
 ublox_device = { path = "../ublox-device", default-features = false, optional = true }

--- a/examples/basic-cli/src/main.rs
+++ b/examples/basic-cli/src/main.rs
@@ -1,12 +1,12 @@
 use chrono::prelude::*;
 use std::convert::TryInto;
-use ublox::*;
+use ublox_device::ublox::*;
 
 fn main() {
     let mut cli = ublox_device::cli::CommandBuilder::default().build();
     cli = cli
-        .about("Demonstrate basic usage of uBlox package")
-        .name("basic_cli")
+        .about(clap::crate_description!())
+        .name(clap::crate_name!())
         .author(clap::crate_authors!());
 
     let serialport = ublox_device::cli::Command::serialport(cli.clone())

--- a/examples/dds/Cargo.toml
+++ b/examples/dds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Andrei Gherghescu <andrei-ng@protonmail.com>"]
-description = "uBlox DDS example"
+description = "Use Data Distribution Service (DDS) to send data across LAN"
 name = "dds"
 publish = false
 rust-version.workspace = true
@@ -9,11 +9,10 @@ edition.workspace = true
 version = "0.1.0"
 
 [features]
-default = ["alloc", "ubx_proto23"]
-alloc = ["ublox/alloc"]
-ubx_proto23 = ["ublox/ubx_proto23", "ublox_device/ubx_proto23"]
-ubx_proto27 = ["ublox/ubx_proto27", "ublox_device/ubx_proto27"]
-ubx_proto31 = ["ublox/ubx_proto31", "ublox_device/ubx_proto31"]
+default = ["ubx_proto23"]
+ubx_proto23 = ["ublox_device/ubx_proto23"]
+ubx_proto27 = ["ublox_device/ubx_proto27"]
+ubx_proto31 = ["ublox_device/ubx_proto31"]
 
 [dependencies]
 chrono = "0.4"
@@ -28,7 +27,6 @@ smol = { version = "2.0" }
 rustdds = "0.11"
 
 ublox_device = { path = "../ublox-device", default-features = false, optional = true }
-ublox = { path = "../../ublox", default-features = false, optional = true }
 
 [[bin]]
 name = "dds-nav-pvt-publisher"

--- a/examples/dds/src/bin/nav-pvt-publisher.rs
+++ b/examples/dds/src/bin/nav-pvt-publisher.rs
@@ -3,8 +3,8 @@ use dds::{cli, idl};
 use log::{debug, error, info, trace, warn};
 use rustdds::{with_key::DataWriter, DomainParticipant};
 use std::{io::ErrorKind, time};
-use ublox::{
-    CfgMsgAllPorts, CfgMsgAllPortsBuilder, MonVer, NavPvt, NavPvtFlags2, PacketRef,
+use ublox_device::ublox::{
+    self, CfgMsgAllPorts, CfgMsgAllPortsBuilder, MonVer, NavPvt, NavPvtFlags2, PacketRef,
     UbxPacketRequest,
 };
 use ublox_device::UbxPacketHandler;

--- a/examples/send-receive/Cargo.toml
+++ b/examples/send-receive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-authors = ["Andrei Gherghescu <gandrein@pm.me>"]
+authors = ["Andrei Gherghescu <andrei-ng@protonmail.com>"]
 name = "send-receive"
-description = "uBlox using two threads, one for reading one for writing"
+description = "Demonstrate usage of the uBlox package for ESF+ADR mode with one thread for receiving and one for sending UBX messages."
 publish = false
 edition.workspace = true
 rust-version.workspace = true
@@ -9,16 +9,14 @@ license.workspace = true
 version = "0.1.0"
 
 [features]
-default = ["alloc", "ubx_proto23"]
-alloc = ["ublox/alloc"]
-ubx_proto23 = ["ublox/ubx_proto23", "ublox_device/ubx_proto23"]
-ubx_proto27 = ["ublox/ubx_proto27", "ublox_device/ubx_proto27"]
-ubx_proto31 = ["ublox/ubx_proto31", "ublox_device/ubx_proto31"]
+default = ["ubx_proto23"]
+ubx_proto23 = ["ublox_device/ubx_proto23"]
+ubx_proto27 = ["ublox_device/ubx_proto27"]
+ubx_proto31 = ["ublox_device/ubx_proto31"]
 
 [dependencies]
 chrono = "0.4"
 clap = { version = "4.2", features = ["cargo"] }
 serialport = "4.2"
 
-ublox = { path = "../../ublox", default-features = false, optional = true }
 ublox_device = { path = "../ublox-device", default-features = false, optional = true }

--- a/examples/send-receive/src/main.rs
+++ b/examples/send-receive/src/main.rs
@@ -3,13 +3,13 @@ use serialport::SerialPort;
 use std::convert::TryInto;
 use std::thread;
 use std::time::Duration;
-use ublox::*;
+use ublox_device::ublox::*;
 
 fn main() {
     let mut cli = ublox_device::cli::CommandBuilder::default().build();
     cli = cli
-        .about("uBlox multi-threaded CLI example program for ESF/ADR operation.")
-        .name("Demonstrate usage of the uBlox package for ESF+ADR mode with one thread for receiving and one for sending UBX messages.")
+        .about(clap::crate_description!())
+        .name(clap::crate_name!())
         .author(clap::crate_authors!());
 
     let serialport = ublox_device::cli::Command::serialport(cli.clone())

--- a/examples/ublox-device/Cargo.toml
+++ b/examples/ublox-device/Cargo.toml
@@ -9,8 +9,7 @@ license.workspace = true
 version = "0.1.0"
 
 [features]
-default = ["alloc", "ubx_proto23"]
-alloc = ["ublox/alloc"]
+default = ["ubx_proto23"]
 ubx_proto23 = ["ublox/ubx_proto23"]
 ubx_proto27 = ["ublox/ubx_proto27"]
 ubx_proto31 = ["ublox/ubx_proto31"]
@@ -20,4 +19,4 @@ anyhow = "1.0"
 clap = { version = "4.2", features = ["cargo"] }
 serialport = "4.2"
 
-ublox = { path = "../../ublox", default-features = false }
+ublox = { path = "../../ublox", default-features = false, features = ["alloc"] }

--- a/examples/ublox-device/src/lib.rs
+++ b/examples/ublox-device/src/lib.rs
@@ -1,8 +1,9 @@
 use cli::UbxPortConfiguration;
 use std::time::Duration;
-use ublox::{CfgPrtUart, CfgPrtUartBuilder, PacketRef, Parser, UartMode, UbxPacketMeta};
 
 pub mod cli;
+pub use ublox;
+use ublox::{CfgPrtUart, CfgPrtUartBuilder, PacketRef, Parser, UartMode, UbxPacketMeta};
 
 pub trait UbxPacketHandler {
     fn handle(&mut self, _packet: PacketRef<'_>) {}

--- a/examples/ublox-tui/Cargo.toml
+++ b/examples/ublox-tui/Cargo.toml
@@ -9,11 +9,10 @@ license.workspace = true
 version = "0.1.0"
 
 [features]
-default = ["alloc", "ubx_proto23"]
-alloc = ["ublox/alloc"]
-ubx_proto23 = ["ublox/ubx_proto23", "ublox_device/ubx_proto23"]
-ubx_proto27 = ["ublox/ubx_proto27", "ublox_device/ubx_proto27"]
-ubx_proto31 = ["ublox/ubx_proto31", "ublox_device/ubx_proto31"]
+default = ["ubx_proto23"]
+ubx_proto23 = ["ublox_device/ubx_proto23"]
+ubx_proto27 = ["ublox_device/ubx_proto27"]
+ubx_proto31 = ["ublox_device/ubx_proto31"]
 
 [dependencies]
 anyhow = "1.0"
@@ -32,5 +31,4 @@ tracing-error = "0.2"
 tui-logger = { version = "0.17", features = ["crossterm", "tracing-support"] }
 directories = "6.0"
 
-ublox = { path = "../../ublox", default-features = false, optional = true }
 ublox_device = { path = "../ublox-device", default-features = false, optional = true }

--- a/examples/ublox-tui/src/app.rs
+++ b/examples/ublox-tui/src/app.rs
@@ -1,7 +1,7 @@
 use core::f64;
 use std::{path::PathBuf, vec};
 
-use ublox::{
+use ublox_device::ublox::{
     EsfAlgStatus, EsfMeasData, EsfSensorFaults, EsfSensorStatusCalibration, EsfSensorStatusTime,
     EsfSensorType, EsfStatusFusionMode, EsfStatusImuInit, EsfStatusInsInit, EsfStatusMountAngle,
     EsfStatusWheelTickInit, GnssFixType, NavPvtFlags, NavPvtFlags2,

--- a/examples/ublox-tui/src/backend.rs
+++ b/examples/ublox-tui/src/backend.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::Sender;
 use std::thread;
 use tracing::{debug, error, info, trace};
-use ublox::*;
+use ublox_device::ublox::*;
 
 use crate::app::{
     EsfAlgImuAlignmentWidgetState, EsfAlgStatusWidgetState, EsfMeasurementWidgetState,

--- a/examples/ublox-tui/src/tui.rs
+++ b/examples/ublox-tui/src/tui.rs
@@ -20,7 +20,7 @@ use ratatui::{
 
 use anyhow::Result;
 use tracing::{debug, info, instrument};
-use ublox::SensorData;
+use ublox_device::ublox::{self, SensorData};
 
 use crate::{
     app::{App, UbxStatus},

--- a/examples/ublox-tui/src/ui.rs
+++ b/examples/ublox-tui/src/ui.rs
@@ -12,7 +12,7 @@ use ratatui::{
 };
 
 use tui_logger::{TuiLoggerLevelOutput, TuiLoggerWidget};
-use ublox::{
+use ublox_device::ublox::{
     EsfAlgStatus, EsfSensorFaults, EsfSensorStatusCalibration, EsfSensorStatusTime, EsfSensorType,
     EsfStatusFusionMode, EsfStatusImuInit, EsfStatusInsInit, EsfStatusMountAngle,
     EsfStatusWheelTickInit, GnssFixType, NavPvtFlags, NavPvtFlags2,


### PR DESCRIPTION
I've simplified a bit the Cargo.toml's of the examples and removed unecessary duplication of feature specification.