### PR TITLE
hide syntect behind the '_internal_debug' feature to prevent it being…

### DIFF
--- a/ublox_derive/Cargo.toml
+++ b/ublox_derive/Cargo.toml
@@ -12,8 +12,8 @@ proc-macro = true
 
 [features]
 default = ["std"]
-std = ["syntect"]
-
+std = []
+_internal_debug = ["syntect", "std"]
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/ublox_derive/src/debug.rs
+++ b/ublox_derive/src/debug.rs
@@ -21,7 +21,7 @@ impl DebugContext {
     /// ```
 
     pub fn print_at(&self, file: &str, line: u32, args: std::fmt::Arguments) {
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, feature = "_internal_debug"))]
         if self.enabled {
             println!("[{}:{}] {}", file, line, args);
         }
@@ -29,7 +29,7 @@ impl DebugContext {
 
     /// Prints as is
     pub fn print(&self, msg: impl std::fmt::Display) {
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, feature = "_internal_debug"))]
         if self.enabled {
             println!("{msg}");
         }
@@ -37,7 +37,7 @@ impl DebugContext {
 
     /// Prints formatted code or an error if the code couldn't be formatted
     pub fn print_code(&self, code: impl std::fmt::Display) {
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, feature = "_internal_debug"))]
         if self.enabled {
             match debug_only::format_rust_code(&code) {
                 Ok(formatted_code) => debug_only::print_highlighted(&formatted_code),
@@ -47,7 +47,7 @@ impl DebugContext {
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, feature = "_internal_debug"))]
 mod debug_only {
     // Spawns rustfmt, runs code through it and returns the formatted code
     pub(super) fn format_rust_code(


### PR DESCRIPTION
… included in the 'std' feature

Building 'syntect' can be a hassle, especially for cross-compiling or in a clean chroot environment, due to its dependency on the C library oniguruma