### PR TITLE
refactor parser rs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         feature-args:
           - '' # Default features
+          - 'full'
           - --features "alloc std ubx_proto23"
           - --no-default-features --features "alloc std ubx_proto23"
           - --no-default-features --features "alloc ubx_proto23 sfrbx-gps"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
           - --no-default-features --features "alloc std ubx_proto14 ubx_proto23 ubx_proto27 ubx_proto31"
     steps:
     - uses: actions/checkout@v5
-    - name: Install libudev
-      run: sudo apt-get update && sudo apt-get install -y libudev-dev
+      with:
+        persist-credentials: false
     - name: Install MSRV
       uses: actions-rs/toolchain@v1
       with:
@@ -69,6 +69,8 @@ jobs:
           - serde,ubx_proto27
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Install MSRV
       uses: actions-rs/toolchain@v1
       with:
@@ -98,9 +100,6 @@ jobs:
       with:
         persist-credentials: false
 
-    # - name: Install libudev
-    #   run: sudo apt-get update && sudo apt-get install -y libudev-dev
-
     - name: Install MSRV
       uses: actions-rs/toolchain@v1
       with:
@@ -123,6 +122,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
     
       - name: Install nightly
         uses: actions-rs/toolchain@v1
@@ -146,9 +147,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: taiki-e/install-action@cargo-hack
-      - name: Install libudev
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - uses: Swatinem/rust-cache@v2
       - name: Check MSRV for examples
         run: cargo hack check --rust-version --workspace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,13 +136,13 @@ jobs:
         run: |
             cd ublox_derive
             RUSTDOCFLAGS="--cfg docrs" \
-                cargo +nightly doc --no-deps
+                cargo +nightly doc --no-deps --all-features
       
       - name: ublox
         run: |
             cd ublox
             RUSTDOCFLAGS="--cfg docrs" \
-                cargo +nightly doc --no-deps
+                cargo +nightly doc --no-deps --all-features
 
   msrv:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,23 +83,40 @@ jobs:
 
   build_examples:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example:
+          - ublox-device
+          - ublox-tui
+          - basic-cli
+          - dds
+          - send-receive
+          - simple-parse
     steps:
     - uses: actions/checkout@v5
-    - name: Install libudev
-      run: sudo apt-get update && sudo apt-get install -y libudev-dev
+      with:
+        persist-credentials: false
+
+    # - name: Install libudev
+    #   run: sudo apt-get update && sudo apt-get install -y libudev-dev
+
     - name: Install MSRV
       uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.83.0
         override: true
         components: rustfmt, clippy
+
     - uses: Swatinem/rust-cache@v2
+    
     - name: Build
-      run: cargo build --release --all
+      run: cargo build --release --package ${{ matrix.example }}
+
     - name: Coding style
       run: |
           cargo fmt --all -- --check
-          cargo clippy --all-targets --all -- -D warnings
+          cargo clippy --all-targets --package ${{ matrix.example }} -- -D warnings
   
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -15,5 +15,7 @@ jobs:
     steps:
     - name: Checkout Actions Repository
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Spell Check Repo
       uses: crate-ci/typos@v1.36.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ documentation = "https://docs.rs/ublox/latest/ublox/"
 repository = "https://github.com/ublox-rs/ublox"
 keywords = ["u-blox", "gnss", "gps"]
 readme = "README.md"
-exclude = [".github", "CONTRIBUTING.md"]
+exclude = [".github", "CONTRIBUTING.md", "justfile"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,31 @@
 # Examples
 
 This folder contains the following examples
+ - [simple-parse](./simple-parse)
  - [basic-cli](./basic-cli)
  - [send-receive](./send-receive)
  - [ublox-tui](./ublox-tui)
  - [DDS](./dds/)
 
+# simple-parse
 
-# uBlox Device
+Minimal example of opening a serial device, reading and parsing ubx packets from it.
+
+This example requires the device to have been preconfigured to output messages.
+
+To run the example with uBlox protocol 23 run
+
+```shell
+cargo run -p simple-parse -- -p /dev/ttyACM0
+```
+
+To run it for other protocol versions, first disable the default features and then enable the specific features needed, e.g.,
+
+```shell
+cargo run -p simple-parse --no-default-features --features alloc,ubx_proto27 -- -p /dev/ttyACM0 
+```
+
+# uBlox Device - This kind of ruins all the examples because the device is so generic and complex!
 
 The device configuration and the reading of packets as well as some common CLI arguments have been abstracted away into an `ublox-device` library. This library is for convenience only as it is used throughout all of the examples.
 

--- a/examples/basic-cli/Cargo.toml
+++ b/examples/basic-cli/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["ubx_proto14", "ubx_proto23", "ubx_proto27", "ubx_proto31"]
+default = ["ubx_proto23"]
 ubx_proto14 = ["ublox-device/ubx_proto14"]
 ubx_proto23 = ["ublox-device/ubx_proto23"]
 ubx_proto27 = ["ublox-device/ubx_proto27"]

--- a/examples/basic-cli/Cargo.toml
+++ b/examples/basic-cli/Cargo.toml
@@ -13,13 +13,13 @@ rust-version.workspace = true
 
 [features]
 default = ["ubx_proto14", "ubx_proto23", "ubx_proto27", "ubx_proto31"]
-ubx_proto14 = ["ublox_device/ubx_proto14"]
-ubx_proto23 = ["ublox_device/ubx_proto23"]
-ubx_proto27 = ["ublox_device/ubx_proto27"]
-ubx_proto31 = ["ublox_device/ubx_proto31"]
+ubx_proto14 = ["ublox-device/ubx_proto14"]
+ubx_proto23 = ["ublox-device/ubx_proto23"]
+ubx_proto27 = ["ublox-device/ubx_proto27"]
+ubx_proto31 = ["ublox-device/ubx_proto31"]
 
 [dependencies]
 chrono = "0.4"
 clap = { version = "4.2", features = ["cargo"] }
 
-ublox_device = { path = "../ublox-device", default-features = false, optional = true }
+ublox-device = { path = "../ublox-device", default-features = false, optional = true }

--- a/examples/basic-cli/src/main.rs
+++ b/examples/basic-cli/src/main.rs
@@ -99,11 +99,12 @@ mod handler {
                 if has_posvel {
                     let pos: Position = pvt.into();
                     let vel: Velocity = pvt.into();
-                    println!(
-                                    "NavPvt: Latitude: {:.5} Longitude: {:.5} Altitude: {:.2} m, Speed: {:.2} m/s Heading: {:.2} degrees",
-                                    pos.lat, pos.lon, pos.alt
-                                    ,vel.speed, vel.heading
-                                );
+                    let lat = pos.lat;
+                    let lon = pos.lon;
+                    let alt = pos.alt;
+                    let speed = vel.speed;
+                    let heading = vel.heading;
+                    println!("NavPvt: Latitude: {lat:.5} Longitude: {lon:.5} Altitude: {alt:.2} m, Speed: {speed:.2} m/s Heading: {heading:.2} degrees");
                     println!("NavPvt full: {pvt:?}");
                 }
 

--- a/examples/dds/Cargo.toml
+++ b/examples/dds/Cargo.toml
@@ -10,10 +10,10 @@ version = "0.1.0"
 
 [features]
 default = ["ubx_proto14", "ubx_proto23", "ubx_proto27", "ubx_proto31"]
-ubx_proto14 = ["ublox_device/ubx_proto14"]
-ubx_proto23 = ["ublox_device/ubx_proto23"]
-ubx_proto27 = ["ublox_device/ubx_proto27"]
-ubx_proto31 = ["ublox_device/ubx_proto31"]
+ubx_proto14 = ["ublox-device/ubx_proto14"]
+ubx_proto23 = ["ublox-device/ubx_proto23"]
+ubx_proto27 = ["ublox-device/ubx_proto27"]
+ubx_proto31 = ["ublox-device/ubx_proto31"]
 
 [dependencies]
 chrono = "0.4"
@@ -27,7 +27,7 @@ futures = "0.3"
 smol = { version = "2.0" }
 rustdds = "0.11"
 
-ublox_device = { path = "../ublox-device", default-features = false, optional = true }
+ublox-device = { path = "../ublox-device", default-features = false, optional = true }
 
 [[bin]]
 name = "dds-nav-pvt-publisher"

--- a/examples/send-receive/Cargo.toml
+++ b/examples/send-receive/Cargo.toml
@@ -18,6 +18,6 @@ ubx_proto31 = ["ublox-device/ubx_proto31"]
 [dependencies]
 chrono = "0.4"
 clap = { version = "4.2", features = ["cargo"] }
-serialport = "4.2"
+serialport = { version = "4.2", default-features = false }
 
 ublox-device = { path = "../ublox-device", default-features = false, optional = true }

--- a/examples/send-receive/Cargo.toml
+++ b/examples/send-receive/Cargo.toml
@@ -10,14 +10,14 @@ version = "0.1.0"
 
 [features]
 default = ["ubx_proto14", "ubx_proto23", "ubx_proto27", "ubx_proto31"]
-ubx_proto14 = ["ublox_device/ubx_proto14"]
-ubx_proto23 = ["ublox_device/ubx_proto23"]
-ubx_proto27 = ["ublox_device/ubx_proto27"]
-ubx_proto31 = ["ublox_device/ubx_proto31"]
+ubx_proto14 = ["ublox-device/ubx_proto14"]
+ubx_proto23 = ["ublox-device/ubx_proto23"]
+ubx_proto27 = ["ublox-device/ubx_proto27"]
+ubx_proto31 = ["ublox-device/ubx_proto31"]
 
 [dependencies]
 chrono = "0.4"
 clap = { version = "4.2", features = ["cargo"] }
 serialport = "4.2"
 
-ublox_device = { path = "../ublox-device", default-features = false, optional = true }
+ublox-device = { path = "../ublox-device", default-features = false, optional = true }

--- a/examples/simple-parse/Cargo.toml
+++ b/examples/simple-parse/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "simple-parse"
+version = "0.1.0"
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+documentation.workspace = true
+repository.workspace = true
+keywords.workspace = true
+readme.workspace = true
+exclude.workspace = true
+
+[dependencies]
+clap = { version = "4.2", features = ["derive"] }
+serialport = "4.2"
+ublox = { path = "../../ublox", default-features = false, features = [
+    "alloc",
+    "ubx_proto23",
+] }

--- a/examples/simple-parse/Cargo.toml
+++ b/examples/simple-parse/Cargo.toml
@@ -12,7 +12,7 @@ exclude.workspace = true
 
 [dependencies]
 clap = { version = "4.2", features = ["derive"] }
-serialport = "4.2"
+serialport = { version = "4.2", default-features = false }
 ublox = { path = "../../ublox", default-features = false, features = [
     "alloc",
     "ubx_proto23",

--- a/examples/simple-parse/src/main.rs
+++ b/examples/simple-parse/src/main.rs
@@ -1,0 +1,86 @@
+use clap::Parser;
+use std::io::Read;
+use ublox::UbxPacket;
+
+#[derive(Parser)]
+struct Args {
+    /// Serial port device
+    #[arg(short, long)]
+    port: String,
+
+    /// Baud rate
+    #[arg(short, long, default_value_t = 9600)]
+    baud_rate: u32,
+
+    /// Stop bits (1 or 2)
+    #[arg(short, long, default_value_t = 1)]
+    stop_bits: u8,
+
+    /// Data bits (7 or 8)
+    #[arg(short, long, default_value_t = 8)]
+    data_bits: u8,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let arg_port = args.port;
+    let arg_baud_rate = args.baud_rate;
+
+    let arg_stop_bits = match args.stop_bits {
+        1 => serialport::StopBits::One,
+        2 => serialport::StopBits::Two,
+        _ => return Err("Invalid stop bits. Must be 1 or 2".into()),
+    };
+
+    let arg_data_bits = match args.data_bits {
+        7 => serialport::DataBits::Seven,
+        8 => serialport::DataBits::Eight,
+        _ => return Err("Invalid data bits. Must be 7 or 8".into()),
+    };
+
+    let mut port = serialport::new(&arg_port, arg_baud_rate)
+        .stop_bits(arg_stop_bits)
+        .data_bits(arg_data_bits)
+        .open()?;
+
+    println!(
+        "Serial port '{arg_port}' opened successfully at {arg_baud_rate} baud, {arg_data_bits} data bits, {arg_stop_bits} stop bits!",
+    );
+    let mut parser = ublox::Parser::default();
+    let mut buffer = [0u8; 1024];
+
+    loop {
+        match port.read(&mut buffer) {
+            Ok(bytes_read) => {
+                let mut it = parser.consume_ubx(&buffer[..bytes_read]);
+                loop {
+                    match it.next() {
+                        Some(Ok(UbxPacket::Proto23(p))) => {
+                            println!("Received UBX packet: {p:?}");
+                            match p {
+                                ublox::proto23::PacketRef::NavPvt(nav_pvt) => {
+                                    println!("Speed: {} [m/s]", nav_pvt.ground_speed_2d())
+                                },
+                                _ => (), // Ignore packets we don't care about
+                            };
+                        },
+                        Some(Err(e)) => {
+                            println!("Received malformed packet: {e:?}");
+                        },
+                        None => {
+                            // The internal buffer is now empty
+                            break;
+                        },
+                    }
+                }
+            },
+            Err(e) => {
+                eprintln!("Error reading from serial port: {e}");
+                break;
+            },
+        }
+    }
+
+    Ok(())
+}

--- a/examples/simple-parse/src/main.rs
+++ b/examples/simple-parse/src/main.rs
@@ -62,6 +62,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 ublox::proto23::PacketRef::NavPvt(nav_pvt) => {
                                     println!("Speed: {} [m/s]", nav_pvt.ground_speed_2d())
                                 },
+                                ublox::proto23::PacketRef::EsfMeas(esf_meas) => {
+                                    for data in esf_meas.data() {
+                                        println!("ESF MEAS DATA: {data:?}");
+                                    }
+                                },
                                 _ => (), // Ignore packets we don't care about
                             };
                         },

--- a/examples/ublox-device/Cargo.toml
+++ b/examples/ublox-device/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ublox_device"
+name = "ublox-device"
 authors = ["Andrei Gherghescu <andrei-ng@protonmail.com>"]
 description = "An uBlox device implementation for reuse in examples"
 publish = false

--- a/examples/ublox-device/Cargo.toml
+++ b/examples/ublox-device/Cargo.toml
@@ -18,6 +18,6 @@ ubx_proto31 = ["ublox/ubx_proto31"]
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.2", features = ["cargo"] }
-serialport = "4.2"
+serialport = { version = "4.2", default-features = false }
 
 ublox = { path = "../../ublox", default-features = false, features = ["alloc"] }

--- a/examples/ublox-tui/Cargo.toml
+++ b/examples/ublox-tui/Cargo.toml
@@ -10,10 +10,10 @@ version = "0.1.0"
 
 [features]
 default = ["ubx_proto14", "ubx_proto23", "ubx_proto27", "ubx_proto31"]
-ubx_proto14 = ["ublox_device/ubx_proto14"]
-ubx_proto23 = ["ublox_device/ubx_proto23"]
-ubx_proto27 = ["ublox_device/ubx_proto27"]
-ubx_proto31 = ["ublox_device/ubx_proto31"]
+ubx_proto14 = ["ublox-device/ubx_proto14"]
+ubx_proto23 = ["ublox-device/ubx_proto23"]
+ubx_proto27 = ["ublox-device/ubx_proto27"]
+ubx_proto31 = ["ublox-device/ubx_proto31"]
 
 [dependencies]
 anyhow = "1.0"
@@ -32,4 +32,4 @@ tracing-error = "0.2"
 tui-logger = { version = "0.17", features = ["crossterm", "tracing-support"] }
 directories = "6.0"
 
-ublox_device = { path = "../ublox-device", default-features = false, optional = true }
+ublox-device = { path = "../ublox-device", default-features = false, optional = true }

--- a/examples/ublox-tui/src/ui.rs
+++ b/examples/ublox-tui/src/ui.rs
@@ -45,22 +45,6 @@ impl Widget for &mut LogWidget {
             .output_line(false)
             .style(Style::default().fg(ratatui::style::Color::White))
             .render(area, buf);
-
-        // TuiLoggerSmartWidget::default()
-        //     .title_log("Log")
-        //     .style_error(Style::default().fg(Color::Red))
-        //     .style_debug(Style::default().fg(Color::Green))
-        //     .style_warn(Style::default().fg(Color::Yellow))
-        //     .style_trace(Style::default().fg(Color::Magenta))
-        //     .style_info(Style::default().fg(Color::Cyan))
-        //     .output_separator(':')
-        //     .output_timestamp(Some("%H:%M:%S".to_string()))
-        //     .output_level(Some(TuiLoggerLevelOutput::Abbreviated))
-        //     .output_target(true)
-        //     .output_file(true)
-        //     .output_line(true)
-        // .state(self.selected_state())
-        // .render(area, buf);
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -35,13 +35,13 @@ test-all *ARGS: (cmd-for-all-features "cargo test" ARGS)
 # Build examples
 [group("examples")]
 build-examples:
-    cargo build --release --all
+    cargo build --release --workspace
 
 # Format and lint examples
 [group("examples")]
 lint-examples:
     cargo fmt --all -- --check
-    cargo clippy --all-targets --all -- -D warnings
+    cargo clippy --all-targets --workspace -- -D warnings
 
 # Run formatting and clippy lints
 [group("misc")]
@@ -115,6 +115,25 @@ cmd-for-all-features-embedded CMD *ARGS:
     # Loop through each feature combination
     for feat in "${feature_combinations[@]}"; do
         just run-cmd-verbose "{{CMD}} ${feat} --target thumbv6m-none-eabi --target thumbv7m-none-eabi --target thumbv7em-none-eabihf {{ARGS}}"
+    done
+
+[no-exit-message, group("misc")]
+cmd-for-all-examples CMD *ARGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    examples=(
+        'ublox-device'
+        'ublox-tui'
+        'basic-cli'
+        'dds'
+        'send-receive'
+        'simple-parse'
+    )
+
+    # Loop through each example
+    for example in "${examples[@]}"; do
+        just run-cmd-verbose "{{CMD}} --package ${example} {{ARGS}}"
     done
 
 [private, no-exit-message]

--- a/justfile
+++ b/justfile
@@ -65,8 +65,8 @@ lint-msrv *ARGS:
 # Build docs
 [group("misc")]
 doc $RUSTDOCFLAGS="--cfg docrs":
-    cd ublox_derive && cargo +nightly doc --no-deps
-    cd ublox        && cargo +nightly doc --no-deps
+    cd ublox_derive && cargo +nightly doc --no-deps --all-features
+    cd ublox        && cargo +nightly doc --no-deps --all-features
 
 # Run MSRV checks
 [group("misc")]

--- a/justfile
+++ b/justfile
@@ -34,8 +34,7 @@ test-all *ARGS: (cmd-for-all-features "cargo test" ARGS)
 
 # Build examples
 [group("examples")]
-build-examples:
-    cargo build --release --workspace
+build-examples: (cmd-for-all-examples "cargo build --release")
 
 # Format and lint examples
 [group("examples")]
@@ -79,6 +78,7 @@ cmd-for-all-features CMD *ARGS:
     
     feature_combinations=(
     '' # Default features
+    '--features full'
     '--no-default-features --features "alloc std ubx_proto23"'
     '--no-default-features --features "alloc ubx_proto23 sfrbx-gps"'
     '--no-default-features --features ubx_proto14'

--- a/justfile
+++ b/justfile
@@ -14,7 +14,15 @@ alias l := lint
 
 # Run all CI checks (except semver)
 [group("all")]
-ci: typos lint-msrv build-all build-all-embedded test-all lint-examples build-examples doc msrv
+ci: typos \
+    lint-msrv \
+    build-all \
+    build-all-embedded \
+    test-all \
+    lint-examples \
+    build-examples \
+    doc \
+    msrv
 
 # Check all feature combinations
 [group("all")]

--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -11,11 +11,12 @@ readme.workspace = true
 edition.workspace = true
 
 [features]
+default = ["std", "ubx_proto23"]
 ubx_proto14 = []
 ubx_proto23 = []
 ubx_proto27 = []
 ubx_proto31 = []
-default = [
+full = [
     "std",
     "alloc",
     "serde",

--- a/ublox/Cargo.toml
+++ b/ublox/Cargo.toml
@@ -34,7 +34,7 @@ alloc = []
 std = []
 
 [package.metadata.docs.rs]
-all-features = false
+all-features = true
 rustdoc-args = ["--cfg", "docrs", "--generate-link-to-definition"]
 
 [dependencies]

--- a/ublox/src/lib.rs
+++ b/ublox/src/lib.rs
@@ -10,7 +10,8 @@ extern crate serde;
 pub use crate::{
     error::{DateTimeError, MemWriterError, ParserError},
     parser::{
-        AnyPacketRef, FixedLinearBuffer, Parser, RtcmPacketRef, UbxParserIter, UnderlyingBuffer,
+        AnyPacketRef, FixedLinearBuffer, Parser, ParserBuilder, RtcmPacketRef, UbxParserIter,
+        UnderlyingBuffer,
     },
     ubx_packets::*,
 };
@@ -24,38 +25,26 @@ pub mod proto23;
 pub mod proto27;
 pub mod proto31;
 
-/// Encapsulates all the UBX packets of each protocol.
+/// Unified interface for UBX packets across different protocol versions.
 ///
-/// This enum provides a unified interface for handling UBX packets across different protocol versions.
-/// Each variant corresponds to a specific UBX protocol version and contains the appropriate packet
-/// reference for that protocol.
+/// Each variant corresponds to a UBX protocol version (17, 23, 27, 31).
 ///
-/// # Protocol Versions
-///
-/// The available variants depend on which feature flags are enabled:
-/// - `ubx_proto14`: Enables Protocol 17 support
-/// - `ubx_proto23`: Enables Protocol 23 support
-/// - `ubx_proto27`: Enables Protocol 27 support
-/// - `ubx_proto31`: Enables Protocol 31 support
-///
-/// # Note
-///
-/// Most users will only need one protocol, so with only one protocol feature enabled
-/// the enum will contain a single variant which is the UBX packet variant of the selected protocol.
+/// Most users will only need one protocol, so enable only the relevant feature flag.
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// # use ublox::UbxPacket;
+/// ```rust
+/// use ublox::{UbxPacket, proto23::PacketRef};
+///
 /// match packet {
-///     #[cfg(feature = "ubx_proto14")]
-///     UbxPacket::Proto17(p) => { /* handle proto17 */ }
-///     #[cfg(feature = "ubx_proto23")]
-///     UbxPacket::Proto23(p) => { /* handle proto23 */ }
-///     #[cfg(feature = "ubx_proto27")]
-///     UbxPacket::Proto27(p) => { /* handle proto27 */ }
-///     #[cfg(feature = "ubx_proto31")]
-///     UbxPacket::Proto31(p) => { /* handle proto31 */ }
+///     UbxPacket::Proto23(p) => match p {
+///         PacketRef::NavPvt(nav_pvt) => {
+///             println!("Speed: {} m/s", nav_pvt.ground_speed_2d());
+///         },
+///         _ => {} // Other packet types
+///     }
+///     // Handle other protocol versions if needed
+///     _ => {}
 /// }
 /// ```
 #[derive(Debug)]

--- a/ublox/src/lib.rs
+++ b/ublox/src/lib.rs
@@ -15,6 +15,49 @@ pub use crate::{
     ubx_packets::*,
 };
 
+mod error;
+mod parser;
+mod ubx_packets;
+
+pub mod proto17;
+pub mod proto23;
+pub mod proto27;
+pub mod proto31;
+
+/// Encapsulates all the UBX packets of each protocol.
+///
+/// This enum provides a unified interface for handling UBX packets across different protocol versions.
+/// Each variant corresponds to a specific UBX protocol version and contains the appropriate packet
+/// reference for that protocol.
+///
+/// # Protocol Versions
+///
+/// The available variants depend on which feature flags are enabled:
+/// - `ubx_proto14`: Enables Protocol 17 support
+/// - `ubx_proto23`: Enables Protocol 23 support
+/// - `ubx_proto27`: Enables Protocol 27 support
+/// - `ubx_proto31`: Enables Protocol 31 support
+///
+/// # Note
+///
+/// Most users will only need one protocol, so with only one protocol feature enabled
+/// the enum will contain a single variant which is the UBX packet variant of the selected protocol.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// # use ublox::UbxPacket;
+/// match packet {
+///     #[cfg(feature = "ubx_proto14")]
+///     UbxPacket::Proto17(p) => { /* handle proto17 */ }
+///     #[cfg(feature = "ubx_proto23")]
+///     UbxPacket::Proto23(p) => { /* handle proto23 */ }
+///     #[cfg(feature = "ubx_proto27")]
+///     UbxPacket::Proto27(p) => { /* handle proto27 */ }
+///     #[cfg(feature = "ubx_proto31")]
+///     UbxPacket::Proto31(p) => { /* handle proto31 */ }
+/// }
+/// ```
 #[derive(Debug)]
 pub enum UbxPacket<'a> {
     #[cfg(feature = "ubx_proto14")]
@@ -42,172 +85,3 @@ pub trait UbxProtocol: Send + Sized {
         payload: &[u8],
     ) -> Result<Self::PacketRef<'_>, ParserError>;
 }
-
-#[cfg(feature = "ubx_proto14")]
-pub mod proto17 {
-    //! Protocol 17 specific types
-
-    use crate::ubx_packets::packetref_proto17::{match_packet, MAX_PAYLOAD_LEN};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
-
-    #[doc(inline)]
-    pub use crate::ubx_packets::packetref_proto17::PacketRef;
-
-    impl<'a> From<PacketRef<'a>> for crate::UbxPacket<'a> {
-        fn from(packet: PacketRef<'a>) -> Self {
-            crate::UbxPacket::Proto17(packet)
-        }
-    }
-
-    /// Tag for protocol 17 packets
-    pub struct Proto17;
-
-    impl crate::UbxProtocol for Proto17 {
-        type PacketRef<'a> = PacketRef<'a>;
-        const MAX_PAYLOAD_LEN: usize = MAX_PAYLOAD_LEN as usize;
-
-        fn match_packet(
-            class_id: u8,
-            msg_id: u8,
-            payload: &[u8],
-        ) -> Result<Self::PacketRef<'_>, crate::ParserError> {
-            match_packet(class_id, msg_id, payload)
-        }
-    }
-
-    #[cfg(any(feature = "std", feature = "alloc"))]
-    impl core::default::Default for crate::Parser<Vec<u8>, Proto17> {
-        fn default() -> Self {
-            Self::new(Vec::new())
-        }
-    }
-}
-
-#[cfg(feature = "ubx_proto23")]
-pub mod proto23 {
-    //! Protocol 23 specific types
-
-    use crate::ubx_packets::packetref_proto23::{match_packet, MAX_PAYLOAD_LEN};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
-
-    #[doc(inline)]
-    pub use crate::ubx_packets::packetref_proto23::PacketRef;
-
-    impl<'a> From<PacketRef<'a>> for crate::UbxPacket<'a> {
-        fn from(packet: PacketRef<'a>) -> Self {
-            crate::UbxPacket::Proto23(packet)
-        }
-    }
-
-    /// Tag for protocol 23 packets
-    pub struct Proto23;
-
-    impl crate::UbxProtocol for Proto23 {
-        type PacketRef<'a> = PacketRef<'a>;
-
-        const MAX_PAYLOAD_LEN: usize = MAX_PAYLOAD_LEN as usize;
-
-        fn match_packet(
-            class_id: u8,
-            msg_id: u8,
-            payload: &[u8],
-        ) -> Result<Self::PacketRef<'_>, crate::ParserError> {
-            match_packet(class_id, msg_id, payload)
-        }
-    }
-
-    #[cfg(any(feature = "std", feature = "alloc"))]
-    impl core::default::Default for crate::Parser<Vec<u8>, Proto23> {
-        fn default() -> Self {
-            Self::new(Vec::new())
-        }
-    }
-}
-
-#[cfg(feature = "ubx_proto27")]
-pub mod proto27 {
-    //! Protocol 27 specific types
-
-    use crate::ubx_packets::packetref_proto27::{match_packet, MAX_PAYLOAD_LEN};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
-
-    #[doc(inline)]
-    pub use crate::ubx_packets::packetref_proto27::PacketRef;
-
-    impl<'a> From<PacketRef<'a>> for crate::UbxPacket<'a> {
-        fn from(packet: PacketRef<'a>) -> Self {
-            crate::UbxPacket::Proto27(packet)
-        }
-    }
-
-    /// Tag for protocol 27 packets
-    pub struct Proto27;
-
-    impl crate::UbxProtocol for Proto27 {
-        type PacketRef<'a> = PacketRef<'a>;
-        const MAX_PAYLOAD_LEN: usize = MAX_PAYLOAD_LEN as usize;
-
-        fn match_packet(
-            class_id: u8,
-            msg_id: u8,
-            payload: &[u8],
-        ) -> Result<Self::PacketRef<'_>, crate::ParserError> {
-            match_packet(class_id, msg_id, payload)
-        }
-    }
-
-    #[cfg(any(feature = "std", feature = "alloc"))]
-    impl core::default::Default for crate::Parser<Vec<u8>, Proto27> {
-        fn default() -> Self {
-            Self::new(Vec::new())
-        }
-    }
-}
-
-#[cfg(feature = "ubx_proto31")]
-pub mod proto31 {
-    //! Protocol 31 specific types
-
-    use crate::ubx_packets::packetref_proto31::{match_packet, MAX_PAYLOAD_LEN};
-    #[cfg(feature = "alloc")]
-    use alloc::vec::Vec;
-
-    #[doc(inline)]
-    pub use crate::ubx_packets::packetref_proto31::PacketRef;
-
-    impl<'a> From<PacketRef<'a>> for crate::UbxPacket<'a> {
-        fn from(packet: PacketRef<'a>) -> Self {
-            crate::UbxPacket::Proto31(packet)
-        }
-    }
-
-    /// Tag for protocol 31 packets
-    pub struct Proto31;
-
-    impl crate::UbxProtocol for Proto31 {
-        type PacketRef<'a> = PacketRef<'a>;
-        const MAX_PAYLOAD_LEN: usize = MAX_PAYLOAD_LEN as usize;
-
-        fn match_packet(
-            class_id: u8,
-            msg_id: u8,
-            payload: &[u8],
-        ) -> Result<Self::PacketRef<'_>, crate::ParserError> {
-            match_packet(class_id, msg_id, payload)
-        }
-    }
-
-    #[cfg(any(feature = "std", feature = "alloc"))]
-    impl core::default::Default for crate::Parser<Vec<u8>, Proto31> {
-        fn default() -> Self {
-            Self::new(Vec::new())
-        }
-    }
-}
-
-mod error;
-mod parser;
-mod ubx_packets;

--- a/ublox/src/parser.rs
+++ b/ublox/src/parser.rs
@@ -11,9 +11,11 @@ use core::marker::PhantomData;
 
 // Pick the oldest enabled protocol as the default
 #[cfg(feature = "ubx_proto14")]
+/// The default protocol for types that are generic over protocols, the type of the [DefaultProtocol] depends on which protocol feature(s) are enabled
 pub type DefaultProtocol = crate::proto17::Proto17;
 
 #[cfg(all(not(feature = "ubx_proto14"), feature = "ubx_proto23"))]
+/// The default protocol for types that are generic over protocols, the type of the [DefaultProtocol] depends on which protocol feature(s) are enabled
 pub type DefaultProtocol = crate::proto23::Proto23;
 
 #[cfg(all(
@@ -21,6 +23,7 @@ pub type DefaultProtocol = crate::proto23::Proto23;
     not(feature = "ubx_proto23"),
     feature = "ubx_proto27"
 ))]
+/// The default protocol for types that are generic over protocols, the type of the [DefaultProtocol] depends on which protocol feature(s) are enabled
 pub type DefaultProtocol = crate::proto27::Proto27;
 
 #[cfg(all(
@@ -29,158 +32,100 @@ pub type DefaultProtocol = crate::proto27::Proto27;
     not(feature = "ubx_proto27"),
     feature = "ubx_proto31"
 ))]
+/// The default protocol for types that are generic over protocols, the type of the [DefaultProtocol] depends on which protocol feature(s) are enabled
 pub type DefaultProtocol = crate::proto31::Proto31;
 
-/// This trait represents an underlying buffer used for the Parser. We provide
-/// implementations for `Vec<u8>` and for `FixedLinearBuffer`, if you want to
-/// use your own struct as an underlying buffer you can implement this trait.
+mod buffer;
+use buffer::DualBuffer;
+pub use buffer::{FixedBuffer, FixedLinearBuffer, UnderlyingBuffer};
+
+/// A compile-time builder for constructing UBX protocol parsers with different buffer types and protocols.
 ///
-/// Look at the `flb_*` unit tests for ideas of unit tests you can run against
-/// your own implementations.
-pub trait UnderlyingBuffer:
-    core::ops::Index<core::ops::Range<usize>, Output = [u8]> + core::ops::Index<usize, Output = u8>
-{
-    /// Removes all elements from the buffer.
-    fn clear(&mut self);
+/// Unlike typical builders, `ParserBuilder` performs all configuration at compile time through
+/// the type system rather than storing configuration in fields.
+///
+/// # Examples
+///
+/// ## Basic parser with default settings
+///
+/// ```rust
+/// use ublox::ParserBuilder;
+///
+/// // Creates a parser with Vec<u8> buffer and default protocol
+/// let mut parser = ParserBuilder::new().with_vec_buffer();
+/// ```
+///
+/// ## Parser with fixed-size buffer (no_std compatible)
+///
+/// ```rust
+/// use ublox::ParserBuilder;
+///
+/// // Creates a parser with 1024-byte fixed buffer
+/// let mut parser = ParserBuilder::new().with_fixed_buffer::<1024>();
+/// ```
+///
+/// ## Parser with specific protocol version
+///
+/// ```rust
+/// use ublox::{ParserBuilder, proto23::Proto23};
+///
+/// // Specify protocol version and buffer type
+/// let mut parser = ParserBuilder::new()
+///     .with_protocol::<Proto23>()
+///     .with_vec_buffer();
+/// ```
+///
+/// ## Parser with custom buffer implementation
+///
+/// ```rust
+/// use ublox::{ParserBuilder, FixedLinearBuffer};
+///
+/// let mut my_array = [0u8; 512];
+/// let custom_buffer = FixedLinearBuffer::new(&mut my_array);
+///
+/// let mut parser = ParserBuilder::new()
+///     .with_buffer(custom_buffer);
+/// ```
+pub struct ParserBuilder<P: UbxProtocol = DefaultProtocol> {
+    _phantom: PhantomData<P>,
+}
 
-    /// Returns the number of elements currently stored in the buffer.
-    fn len(&self) -> usize;
-
-    /// Returns the maximum capacity of this buffer. This value should be a minimum max
-    /// capacity - that is, `extend_from_slice` should succeed if max_capacity bytes are
-    /// passed to it.
-    ///
-    /// Note that, for example, the Vec implementation of this trait returns `usize::MAX`,
-    /// which cannot be actually allocated by a Vec. This is okay, because Vec will panic
-    /// if an allocation is requested that it can't handle.
-    fn max_capacity(&self) -> usize;
-
-    /// Returns the number of bytes not copied over due to buffer size constraints.
-    ///
-    /// As noted for `max_capacity`, if this function is passed `max_capacity() - len()`
-    /// bytes it should either panic or return zero bytes, any other behaviour may cause
-    /// unexpected behaviour in the parser.
-    fn extend_from_slice(&mut self, other: &[u8]) -> usize;
-
-    /// Removes the first `count` elements from the buffer. Cannot fail.
-    fn drain(&mut self, count: usize);
-
-    /// Locates the given u8 value within the buffer, returning the index (if it is found).
-    fn find(&self, value: u8) -> Option<usize> {
-        (0..self.len()).find(|&i| self[i] == value)
-    }
-
-    /// Returns whether the buffer is empty.
-    fn is_empty(&self) -> bool {
-        self.len() == 0
+impl Default for ParserBuilder<DefaultProtocol> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-#[cfg(any(feature = "std", feature = "alloc"))]
-impl UnderlyingBuffer for Vec<u8> {
-    fn clear(&mut self) {
-        self.clear();
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-
-    fn max_capacity(&self) -> usize {
-        usize::MAX
-    }
-
-    fn extend_from_slice(&mut self, other: &[u8]) -> usize {
-        self.extend_from_slice(other);
-        0
-    }
-
-    fn drain(&mut self, count: usize) {
-        self.drain(0..count);
-    }
-
-    fn find(&self, value: u8) -> Option<usize> {
-        self.iter().position(|elem| *elem == value)
-    }
-}
-
-pub struct FixedLinearBuffer<'a> {
-    buffer: &'a mut [u8],
-    len: usize,
-}
-
-impl<'a> FixedLinearBuffer<'a> {
-    pub fn new(buf: &'a mut [u8]) -> Self {
+impl ParserBuilder<DefaultProtocol> {
+    pub fn new() -> Self {
         Self {
-            buffer: buf,
-            len: 0,
+            _phantom: PhantomData,
         }
     }
 }
 
-impl core::ops::Index<core::ops::Range<usize>> for FixedLinearBuffer<'_> {
-    type Output = [u8];
-
-    fn index(&self, index: core::ops::Range<usize>) -> &Self::Output {
-        if index.end > self.len {
-            // Same message style as Rust std lib
-            panic!(
-                "index out of bounds: the len is {len} but the index is {idx}",
-                len = self.len,
-                idx = index.end
-            );
+impl<P: UbxProtocol> ParserBuilder<P> {
+    /// Specify a protocol version
+    pub fn with_protocol<NewP: UbxProtocol>(self) -> ParserBuilder<NewP> {
+        ParserBuilder {
+            _phantom: PhantomData,
         }
-        self.buffer.index(index)
-    }
-}
-
-impl core::ops::Index<usize> for FixedLinearBuffer<'_> {
-    type Output = u8;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self.buffer[index]
-    }
-}
-
-impl UnderlyingBuffer for FixedLinearBuffer<'_> {
-    fn clear(&mut self) {
-        self.len = 0;
     }
 
-    fn len(&self) -> usize {
-        self.len
+    /// Build a parser with a `Vec<u8>` buffer
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    pub fn with_vec_buffer(self) -> Parser<Vec<u8>, P> {
+        Parser::new(Vec::new())
     }
 
-    fn max_capacity(&self) -> usize {
-        self.buffer.len()
+    /// Build a parser with a fixed-size buffer (for no_std or when you want bounded memory usage)
+    pub fn with_fixed_buffer<const N: usize>(self) -> Parser<FixedBuffer<N>, P> {
+        Parser::with_fixed_buffer()
     }
 
-    fn extend_from_slice(&mut self, other: &[u8]) -> usize {
-        let to_copy = core::cmp::min(other.len(), self.buffer.len() - self.len);
-        let uncopyable = other.len() - to_copy;
-        self.buffer[self.len..self.len + to_copy].copy_from_slice(&other[..to_copy]);
-        self.len += to_copy;
-        uncopyable
-    }
-
-    fn drain(&mut self, count: usize) {
-        if count >= self.len {
-            self.len = 0;
-            return;
-        }
-
-        let new_size = self.len - count;
-        {
-            let bufptr = self.buffer.as_mut_ptr();
-            unsafe {
-                core::ptr::copy(bufptr.add(count), bufptr, new_size);
-            }
-        }
-        self.len = new_size;
-    }
-
-    fn find(&self, value: u8) -> Option<usize> {
-        (0..self.len()).find(|&i| self[i] == value)
+    /// Build a parser with a custom buffer implementation
+    pub fn with_buffer<T: UnderlyingBuffer>(self, buffer: T) -> Parser<T, P> {
+        Parser::new(buffer)
     }
 }
 
@@ -199,8 +144,25 @@ where
     _phantom: PhantomData<P>,
 }
 
+impl<const N: usize> Parser<FixedBuffer<N>, DefaultProtocol> {
+    /// Creates a new parser with a fixed-size buffer and the default protocol.
+    /// Use this for no_std environments where you want a compile-time known buffer size.
+    pub fn new_fixed() -> Self {
+        Self::with_fixed_buffer()
+    }
+}
+
+impl<const N: usize, P: UbxProtocol> Parser<FixedBuffer<N>, P> {
+    /// Creates a new parser with an owned, fixed-size internal buffer of size N.
+    pub fn with_fixed_buffer() -> Self {
+        Self::new(FixedBuffer::new())
+    }
+}
+
 #[cfg(any(feature = "std", feature = "alloc"))]
 impl Parser<Vec<u8>, DefaultProtocol> {
+    /// Creates a new parser with a `Vec<u8>` buffer and the default protocol.
+    /// This is the simplest way to create a parser for most use cases.
     pub fn default_proto() -> Self {
         Self {
             buf: Vec::new(),
@@ -221,8 +183,14 @@ impl<T: UnderlyingBuffer, P: UbxProtocol> Parser<T, P> {
         self.buf.is_empty()
     }
 
+    /// Returns the number of elements in the buffer
     pub fn buffer_len(&self) -> usize {
         self.buf.len()
+    }
+
+    /// Returns the total number of elements the buffer can hold
+    pub fn buffer_capacity(&self) -> usize {
+        self.buf.max_capacity()
     }
 
     pub fn consume_ubx<'a>(&'a mut self, new_data: &'a [u8]) -> UbxParserIter<'a, T, P> {
@@ -255,187 +223,6 @@ impl<T: UnderlyingBuffer, P: UbxProtocol> Parser<T, P> {
             buf,
             _phantom: PhantomData,
         }
-    }
-}
-
-/// Stores two buffers: A "base" and a "new" buffer. Exposes these as the same buffer,
-/// copying data from the "new" buffer to the base buffer as required to maintain that
-/// illusion.
-struct DualBuffer<'a, T: UnderlyingBuffer> {
-    buf: &'a mut T,
-    off: usize,
-
-    new_buf: &'a [u8],
-    new_buf_offset: usize,
-}
-
-impl<T: UnderlyingBuffer> core::ops::Index<usize> for DualBuffer<'_, T> {
-    type Output = u8;
-
-    fn index(&self, index: usize) -> &u8 {
-        if self.off + index < self.buf.len() {
-            &self.buf[index + self.off]
-        } else {
-            &self.new_buf[self.new_buf_offset + index - (self.buf.len() - self.off)]
-        }
-    }
-}
-
-impl<'a, T: UnderlyingBuffer> DualBuffer<'a, T> {
-    fn new(buf: &'a mut T, new_buf: &'a [u8]) -> Self {
-        Self {
-            buf,
-            off: 0,
-            new_buf,
-            new_buf_offset: 0,
-        }
-    }
-
-    /// Clears all elements - equivalent to buf.drain(buf.len())
-    fn clear(&mut self) {
-        self.drain(self.len());
-    }
-
-    /// Remove count elements without providing a view into them.
-    fn drain(&mut self, count: usize) {
-        let underlying_bytes = core::cmp::min(self.buf.len() - self.off, count);
-        let new_bytes = count.saturating_sub(underlying_bytes);
-
-        self.off += underlying_bytes;
-        self.new_buf_offset += new_bytes;
-    }
-
-    /// Return the total number of accessible bytes in this view. Note that you may
-    /// not be able to take() this many bytes at once, if the total number of bytes
-    /// is more than the underlying store can fit.
-    fn len(&self) -> usize {
-        self.buf.len() - self.off + self.new_buf.len() - self.new_buf_offset
-    }
-
-    // Returns the number of bytes which would be lost (because they can't be copied into
-    // the underlying storage) if this DualBuffer were dropped.
-    fn potential_lost_bytes(&self) -> usize {
-        if self.len() <= self.buf.max_capacity() {
-            0
-        } else {
-            self.len() - self.buf.max_capacity()
-        }
-    }
-
-    fn can_drain_and_take(&self, drain: usize, take: usize) -> bool {
-        let underlying_bytes = core::cmp::min(self.buf.len() - self.off, drain);
-        let new_bytes = drain.saturating_sub(underlying_bytes);
-
-        let drained_off = self.off + underlying_bytes;
-        let drained_new_off = self.new_buf_offset + new_bytes;
-
-        if take > self.buf.len() - drained_off + self.new_buf.len() - drained_new_off {
-            // Draining removed too many bytes, we don't have enough to take
-            return false;
-        }
-
-        let underlying_bytes = core::cmp::min(self.buf.len() - drained_off, take);
-        let new_bytes = take.saturating_sub(underlying_bytes);
-
-        if underlying_bytes == 0 {
-            // We would take entirely from the new buffer
-            return true;
-        }
-
-        if new_bytes == 0 {
-            // We would take entirely from the underlying
-            return true;
-        }
-
-        if new_bytes > self.buf.max_capacity() - (self.buf.len() - drained_off) {
-            // We wouldn't be able to fit all the new bytes into underlying
-            return false;
-        }
-
-        true
-    }
-
-    fn peek_raw(&self, range: core::ops::Range<usize>) -> (&[u8], &[u8]) {
-        let split = self.buf.len() - self.off;
-        let a = if range.start >= split {
-            &[]
-        } else {
-            &self.buf[range.start + self.off..core::cmp::min(self.buf.len(), range.end + self.off)]
-        };
-        let b = if range.end <= split {
-            &[]
-        } else {
-            &self.new_buf[self.new_buf_offset + range.start.saturating_sub(split)
-                ..range.end - split + self.new_buf_offset]
-        };
-        (a, b)
-    }
-
-    /// Provide a view of the next count elements, moving data if necessary.
-    /// If the underlying store cannot store enough elements, no data is moved and an
-    /// error is returned.
-    fn take(&mut self, count: usize) -> Result<&[u8], ParserError> {
-        let underlying_bytes = core::cmp::min(self.buf.len() - self.off, count);
-        let new_bytes = count.saturating_sub(underlying_bytes);
-
-        if new_bytes > self.new_buf.len() - self.new_buf_offset {
-            // We need to pull more bytes from new than it has
-            panic!(
-                "Cannot pull {} bytes from a buffer with {}-{}",
-                new_bytes,
-                self.new_buf.len(),
-                self.new_buf_offset
-            );
-        }
-
-        if underlying_bytes == 0 {
-            // We can directly return a slice from new
-            let offset = self.new_buf_offset;
-            self.new_buf_offset += count;
-            return Ok(&self.new_buf[offset..offset + count]);
-        }
-
-        if new_bytes == 0 {
-            // We can directly return from underlying
-            let offset = self.off;
-            self.off += count;
-            return Ok(&self.buf[offset..offset + count]);
-        }
-
-        if self.buf.max_capacity() < count {
-            // Insufficient space
-            return Err(ParserError::OutOfMemory {
-                required_size: count,
-            });
-        }
-
-        if new_bytes < self.buf.max_capacity() - self.buf.len() {
-            // Underlying has enough space to extend from new
-            let bytes_not_moved = self
-                .buf
-                .extend_from_slice(&self.new_buf[self.new_buf_offset..]);
-            self.new_buf_offset += self.new_buf.len() - self.new_buf_offset - bytes_not_moved;
-            let off = self.off;
-            self.off += count;
-            return Ok(&self.buf[off..off + count]);
-        }
-
-        // Last case: We have to move the data in underlying, then extend it
-        self.buf.drain(self.off);
-        self.off = 0;
-        self.buf
-            .extend_from_slice(&self.new_buf[self.new_buf_offset..self.new_buf_offset + new_bytes]);
-        self.new_buf_offset += new_bytes;
-        self.off += count;
-        Ok(&self.buf[0..count])
-    }
-}
-
-impl<T: UnderlyingBuffer> Drop for DualBuffer<'_, T> {
-    fn drop(&mut self) {
-        self.buf.drain(self.off);
-        self.buf
-            .extend_from_slice(&self.new_buf[self.new_buf_offset..]);
     }
 }
 
@@ -678,246 +465,37 @@ mod test {
     use crate::ubx_packets::packets::cfg_nav5::*;
     use crate::ubx_packets::*;
 
+    #[cfg(all(feature = "alloc", feature = "ubx_proto23", feature = "ubx_proto31"))]
+    #[test]
+    fn build_parser() {
+        use crate::{proto23::Proto23, proto31::Proto31};
+        // Default protocol with Vec buffer
+        let parser = ParserBuilder::new().with_vec_buffer();
+        assert_eq!(parser.buffer_capacity(), usize::MAX);
+        assert_eq!(parser.buffer_len(), 0);
+
+        // Different protocol
+        const BUF_SZ_0: usize = 2048;
+        let parser = ParserBuilder::new()
+            .with_protocol::<Proto23>()
+            .with_fixed_buffer::<BUF_SZ_0>();
+        assert_eq!(parser.buffer_capacity(), BUF_SZ_0);
+        assert_eq!(parser.buffer_len(), 0);
+
+        // Custom buffer
+        const BUF_SZ_1: usize = 512;
+        let mut my_buffer = [0; BUF_SZ_1];
+        let buffer = FixedLinearBuffer::new(&mut my_buffer);
+        let parser = ParserBuilder::new()
+            .with_protocol::<Proto31>()
+            .with_buffer(buffer);
+
+        assert_eq!(parser.buffer_capacity(), BUF_SZ_1);
+        assert_eq!(parser.buffer_len(), 0);
+    }
+
     #[cfg(feature = "alloc")]
     use alloc::vec;
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn dl_split_indexing() {
-        let mut buf = vec![1, 2, 3, 4];
-        let new = [5, 6, 7, 8];
-        let dual = DualBuffer::new(&mut buf, &new[..]);
-        for i in 0..8 {
-            assert_eq!(dual[i], i as u8 + 1);
-        }
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    #[should_panic]
-    fn dl_take_too_many() {
-        let mut buf = vec![1, 2, 3, 4];
-        let new = [];
-        {
-            let mut dual = DualBuffer::new(&mut buf, &new[..]);
-
-            // This should panic
-            let _ = dual.take(6);
-        }
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn dl_take_range_underlying() {
-        let mut buf = vec![1, 2, 3, 4];
-        let new = [];
-        {
-            let mut dual = DualBuffer::new(&mut buf, &new[..]);
-            let x = dual.take(3).unwrap();
-            assert_eq!(x, &[1, 2, 3]);
-        }
-        assert_eq!(buf, &[4]);
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn dl_take_range_new() {
-        let mut buf = vec![];
-        let new = [1, 2, 3, 4];
-        {
-            let mut dual = DualBuffer::new(&mut buf, &new[..]);
-            let x = dual.take(3).unwrap();
-            assert_eq!(x, &[1, 2, 3]);
-        }
-        assert_eq!(buf, &[4]);
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn dl_take_range_overlapping() {
-        let mut buf = vec![1, 2, 3, 4];
-        let new = [5, 6, 7, 8];
-        {
-            let mut dual = DualBuffer::new(&mut buf, &new[..]);
-            let x = dual.take(6).unwrap();
-            assert_eq!(x, &[1, 2, 3, 4, 5, 6]);
-        }
-        assert_eq!(buf, &[7, 8]);
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn dl_take_multi_ranges() {
-        let mut buf = vec![1, 2, 3, 4, 5, 6, 7];
-        let new = [8, 9, 10, 11, 12];
-        {
-            let mut dual = DualBuffer::new(&mut buf, &new[..]);
-            assert_eq!(dual.take(3).unwrap(), &[1, 2, 3]);
-            assert_eq!(dual.take(3).unwrap(), &[4, 5, 6]);
-            assert_eq!(dual.take(3).unwrap(), &[7, 8, 9]);
-            assert_eq!(dual.take(3).unwrap(), &[10, 11, 12]);
-        }
-        assert!(buf.is_empty());
-    }
-
-    #[cfg(feature = "alloc")]
-    #[test]
-    fn dl_take_multi_ranges2() {
-        let mut buf = vec![1, 2, 3, 4, 5, 6, 7];
-        let new = [8, 9, 10, 11, 12];
-        {
-            let mut dual = DualBuffer::new(&mut buf, &new[..]);
-            assert_eq!(dual.take(3).unwrap(), &[1, 2, 3]);
-            assert_eq!(dual.take(6).unwrap(), &[4, 5, 6, 7, 8, 9]);
-        }
-        assert_eq!(buf, &[10, 11, 12]);
-    }
-
-    #[test]
-    fn dl_move_then_copy() {
-        let mut buf = [0; 7];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
-        let new = [8, 9, 10, 11, 12];
-        {
-            let mut dual = DualBuffer::new(&mut buf, &new[..]);
-            assert_eq!(dual.take(3).unwrap(), &[1, 2, 3]);
-            assert_eq!(dual.take(6).unwrap(), &[4, 5, 6, 7, 8, 9]);
-        }
-        assert_eq!(buf.len(), 3);
-    }
-
-    #[test]
-    #[should_panic]
-    fn dl_take_range_oom() {
-        let mut buf = [0; 4];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        let new = [1, 2, 3, 4, 5, 6];
-
-        let mut dual = DualBuffer::new(&mut buf, &new[..]);
-        // This should throw
-        assert!(
-            matches!(dual.take(6), Err(ParserError::OutOfMemory { required_size }) if required_size == 6)
-        );
-    }
-
-    #[test]
-    fn dl_drain_partial_underlying() {
-        let mut buf = [0; 4];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3]);
-        let new = [4, 5, 6, 7, 8, 9];
-        let mut dual = DualBuffer::new(&mut buf, &new[..]);
-
-        dual.drain(2);
-        assert_eq!(dual.len(), 7);
-        assert_eq!(dual.take(4).unwrap(), &[3, 4, 5, 6]);
-        assert_eq!(dual.len(), 3);
-    }
-
-    #[test]
-    fn dl_drain() {
-        let mut buf = [0; 4];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3]);
-        let new = [4, 5, 6, 7, 8, 9];
-        let mut dual = DualBuffer::new(&mut buf, &new[..]);
-
-        dual.drain(5);
-        assert_eq!(dual.take(3).unwrap(), &[6, 7, 8]);
-        assert_eq!(dual.len(), 1);
-    }
-
-    #[test]
-    fn dl_clear() {
-        let mut buf = [0; 4];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3]);
-        let new = [4, 5, 6, 7, 8, 9];
-        let mut dual = DualBuffer::new(&mut buf, &new[..]);
-
-        assert_eq!(dual.len(), 9);
-        dual.clear();
-        assert_eq!(dual.len(), 0);
-    }
-
-    #[test]
-    fn dl_peek_raw() {
-        let mut buf = [0; 4];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3]);
-        let new = [4, 5, 6, 7, 8, 9];
-        let dual = DualBuffer::new(&mut buf, &new[..]);
-
-        let (a, b) = dual.peek_raw(2..6);
-        assert_eq!(a, &[3]);
-        assert_eq!(b, &[4, 5, 6]);
-    }
-
-    #[test]
-    fn flb_clear() {
-        let mut buf = [0; 16];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
-        assert_eq!(buf.len(), 7);
-        buf.clear();
-        assert_eq!(buf.len(), 0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn flb_index_outside_range() {
-        let mut buf = [0; 16];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
-        let _ = buf[5..10];
-    }
-
-    #[test]
-    fn flb_extend_outside_range() {
-        let mut buf = [0; 16];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
-        assert_eq!(buf.len(), 16);
-    }
-
-    #[test]
-    fn flb_drain() {
-        let mut buf = [0; 16];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
-
-        buf.drain(3);
-        assert_eq!(buf.len(), 4);
-        assert_eq!(&buf[0..buf.len()], &[4, 5, 6, 7]);
-
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
-        assert_eq!(buf.len(), 11);
-        assert_eq!(&buf[0..buf.len()], &[4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]);
-    }
-
-    #[test]
-    fn flb_drain_all() {
-        let mut buf = [0; 16];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
-
-        buf.drain(7);
-        assert_eq!(buf.len(), 0);
-    }
-
-    #[test]
-    fn flb_find() {
-        let mut buf = [1, 2, 3, 4, 5, 6, 7, 8];
-        let mut buf = FixedLinearBuffer::new(&mut buf);
-        assert_eq!(buf.find(5), None);
-        buf.extend_from_slice(&[1, 2, 3, 4]);
-        assert_eq!(buf.find(5), None);
-        buf.extend_from_slice(&[5, 6, 7, 8]);
-        assert_eq!(buf.find(5), Some(4));
-    }
 
     #[cfg(feature = "alloc")]
     #[test]
@@ -1133,8 +711,9 @@ mod test {
         use crate::proto27::{PacketRef, Proto27};
         let bytes = test_util_cfg_nav5_bytes();
 
-        let mut buffer = [0; 12];
-        let mut parser = Parser::<_, Proto27>::new(FixedLinearBuffer::new(&mut buffer));
+        let mut parser = ParserBuilder::new()
+            .with_protocol::<Proto27>()
+            .with_fixed_buffer::<12>();
 
         {
             let mut it = parser.consume_ubx(&bytes[0..8]);
@@ -1168,9 +747,9 @@ mod test {
         use crate::proto31::{PacketRef, Proto31};
 
         let bytes = test_util_cfg_nav5_bytes();
-
-        let mut buffer = [0; 12];
-        let mut parser = Parser::<_, Proto31>::new(FixedLinearBuffer::new(&mut buffer));
+        let mut parser = ParserBuilder::new()
+            .with_protocol::<Proto31>()
+            .with_fixed_buffer::<12>();
 
         {
             let mut it = parser.consume_ubx(&bytes[0..8]);
@@ -1204,10 +783,9 @@ mod test {
         use crate::proto17::{PacketRef, Proto17};
 
         let bytes = test_util_cfg_nav5_bytes();
-
-        let mut buffer = [0; 1024];
-        let buffer = FixedLinearBuffer::new(&mut buffer);
-        let mut parser: Parser<FixedLinearBuffer<'_>, Proto17> = Parser::new(buffer);
+        let mut parser = ParserBuilder::new()
+            .with_protocol::<Proto17>()
+            .with_fixed_buffer::<1024>();
         let mut it = parser.consume_ubx(&bytes);
         assert!(matches!(
             it.next(),
@@ -1222,9 +800,7 @@ mod test {
         use crate::proto23::{PacketRef, Proto23};
         let bytes = test_util_cfg_nav5_bytes();
 
-        let mut buffer = [0; 1024];
-        let buffer = FixedLinearBuffer::new(&mut buffer);
-        let mut parser: Parser<FixedLinearBuffer<'_>, Proto23> = Parser::new(buffer);
+        let mut parser = Parser::<FixedBuffer<1024>, Proto23>::with_fixed_buffer();
         let mut it = parser.consume_ubx(&bytes);
         assert!(matches!(
             it.next(),
@@ -1238,10 +814,9 @@ mod test {
     fn parser_accepts_packet_array_underlying_proto27() {
         use crate::proto27::{PacketRef, Proto27};
         let bytes = test_util_cfg_nav5_bytes();
-
-        let mut buffer = [0; 1024];
-        let buffer = FixedLinearBuffer::new(&mut buffer);
-        let mut parser: Parser<FixedLinearBuffer<'_>, Proto27> = Parser::new(buffer);
+        let mut parser = ParserBuilder::new()
+            .with_protocol::<Proto27>()
+            .with_fixed_buffer::<1024>();
         let mut it = parser.consume_ubx(&bytes);
         assert!(matches!(
             it.next(),
@@ -1256,9 +831,9 @@ mod test {
         use crate::proto31::{PacketRef, Proto31};
         let bytes = test_util_cfg_nav5_bytes();
 
-        let mut buffer = [0; 1024];
-        let buffer = FixedLinearBuffer::new(&mut buffer);
-        let mut parser: Parser<FixedLinearBuffer<'_>, Proto31> = Parser::new(buffer);
+        let mut parser = ParserBuilder::new()
+            .with_protocol::<Proto31>()
+            .with_fixed_buffer::<1024>();
         let mut it = parser.consume_ubx(&bytes);
         assert!(matches!(
             it.next(),

--- a/ublox/src/parser/buffer.rs
+++ b/ublox/src/parser/buffer.rs
@@ -1,0 +1,687 @@
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+use crate::ParserError;
+use core::cmp::min;
+
+/// This trait represents an underlying buffer used for the Parser. We provide
+/// implementations for `Vec<u8>` and for `FixedLinearBuffer`, if you want to
+/// use your own struct as an underlying buffer you can implement this trait.
+///
+/// Look at the `flb_*` unit tests for ideas of unit tests you can run against
+/// your own implementations.
+pub trait UnderlyingBuffer:
+    core::ops::Index<core::ops::Range<usize>, Output = [u8]> + core::ops::Index<usize, Output = u8>
+{
+    /// Removes all elements from the buffer.
+    fn clear(&mut self);
+
+    /// Returns the number of elements currently stored in the buffer.
+    fn len(&self) -> usize;
+
+    /// Returns the maximum capacity of this buffer. This value should be a minimum max
+    /// capacity - that is, `extend_from_slice` should succeed if max_capacity bytes are
+    /// passed to it.
+    ///
+    /// Note that, for example, the Vec implementation of this trait returns `usize::MAX`,
+    /// which cannot be actually allocated by a Vec. This is okay, because Vec will panic
+    /// if an allocation is requested that it can't handle.
+    fn max_capacity(&self) -> usize;
+
+    /// Returns the number of bytes not copied over due to buffer size constraints.
+    ///
+    /// As noted for `max_capacity`, if this function is passed `max_capacity() - len()`
+    /// bytes it should either panic or return zero bytes, any other behaviour may cause
+    /// unexpected behaviour in the parser.
+    fn extend_from_slice(&mut self, other: &[u8]) -> usize;
+
+    /// Removes the first `count` elements from the buffer. Cannot fail.
+    fn drain(&mut self, count: usize);
+
+    /// Locates the given u8 value within the buffer, returning the index (if it is found).
+    fn find(&self, value: u8) -> Option<usize> {
+        (0..self.len()).find(|&i| self[i] == value)
+    }
+
+    /// Returns whether the buffer is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl UnderlyingBuffer for Vec<u8> {
+    fn clear(&mut self) {
+        self.clear();
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn max_capacity(&self) -> usize {
+        usize::MAX
+    }
+
+    fn extend_from_slice(&mut self, other: &[u8]) -> usize {
+        self.extend_from_slice(other);
+        0
+    }
+
+    fn drain(&mut self, count: usize) {
+        self.drain(0..count);
+    }
+
+    fn find(&self, value: u8) -> Option<usize> {
+        self.iter().position(|elem| *elem == value)
+    }
+}
+
+/// Holds a mutable reference to a fixed byte array
+pub struct FixedLinearBuffer<'a> {
+    buffer: &'a mut [u8],
+    len: usize,
+}
+
+impl<'a> FixedLinearBuffer<'a> {
+    pub fn new(buf: &'a mut [u8]) -> Self {
+        Self {
+            buffer: buf,
+            len: 0,
+        }
+    }
+}
+
+impl core::ops::Index<core::ops::Range<usize>> for FixedLinearBuffer<'_> {
+    type Output = [u8];
+
+    fn index(&self, index: core::ops::Range<usize>) -> &Self::Output {
+        if index.end > self.len {
+            // Same message style as Rust std lib
+            panic!(
+                "index out of bounds: the len is {len} but the index is {idx}",
+                len = self.len,
+                idx = index.end
+            );
+        }
+        self.buffer.index(index)
+    }
+}
+
+impl core::ops::Index<usize> for FixedLinearBuffer<'_> {
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.buffer[index]
+    }
+}
+
+impl UnderlyingBuffer for FixedLinearBuffer<'_> {
+    fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn max_capacity(&self) -> usize {
+        self.buffer.len()
+    }
+
+    fn extend_from_slice(&mut self, other: &[u8]) -> usize {
+        let available_space = self.buffer.len() - self.len;
+        let to_copy = min(other.len(), available_space);
+
+        self.buffer[self.len..self.len + to_copy].copy_from_slice(&other[..to_copy]);
+        self.len += to_copy;
+
+        other.len() - to_copy // Remainder that didn't fit in the buffer
+    }
+
+    fn drain(&mut self, count: usize) {
+        if count >= self.len {
+            self.len = 0;
+            return;
+        }
+
+        let remaining = self.len - count;
+        // Move the remaining elements to the start of the buffer
+        self.buffer.copy_within(count..self.len, 0);
+        self.len = remaining;
+    }
+}
+
+/// An owned, fixed-size linear buffer with a capacity known at compile time.
+///
+/// This struct owns its data in a `[u8; N]` array.
+/// It implements the `UnderlyingBuffer` trait, making it
+/// a drop-in replacement for `FixedLinearBuffer` where owned data is preferred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FixedBuffer<const N: usize> {
+    buffer: [u8; N],
+    len: usize,
+}
+
+impl<const N: usize> FixedBuffer<N> {
+    /// Creates a new, empty `FixedBuffer`.
+    pub fn new() -> Self {
+        Self {
+            buffer: [0; N],
+            len: 0,
+        }
+    }
+}
+
+impl<const N: usize> Default for FixedBuffer<N> {
+    /// Creates a new, empty `FixedBuffer`.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize> core::ops::Index<core::ops::Range<usize>> for FixedBuffer<N> {
+    type Output = [u8];
+
+    fn index(&self, index: core::ops::Range<usize>) -> &Self::Output {
+        if index.end > self.len {
+            panic!(
+                "index out of bounds: the len is {len} but the index is {idx}",
+                len = self.len,
+                idx = index.end
+            );
+        }
+        &self.buffer[index]
+    }
+}
+
+impl<const N: usize> core::ops::Index<usize> for FixedBuffer<N> {
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        if index >= self.len {
+            panic!(
+                "index out of bounds: the len is {len} but the index is {idx}",
+                len = self.len,
+                idx = index
+            );
+        }
+        &self.buffer[index]
+    }
+}
+
+impl<const N: usize> UnderlyingBuffer for FixedBuffer<N> {
+    fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn max_capacity(&self) -> usize {
+        N
+    }
+
+    fn extend_from_slice(&mut self, other: &[u8]) -> usize {
+        let available_space = N - self.len;
+        let to_copy = min(other.len(), available_space);
+
+        self.buffer[self.len..self.len + to_copy].copy_from_slice(&other[..to_copy]);
+        self.len += to_copy;
+
+        other.len() - to_copy // Remainder that didn't fit in the buffer
+    }
+
+    fn drain(&mut self, count: usize) {
+        if count >= self.len {
+            self.len = 0;
+            return;
+        }
+
+        let remaining = self.len - count;
+        // Move the remaining elements to the start of the buffer
+        self.buffer.copy_within(count..self.len, 0);
+        self.len = remaining;
+    }
+}
+
+/// Stores two buffers: A "base" and a "new" buffer. Exposes these as the same buffer,
+/// copying data from the "new" buffer to the base buffer as required to maintain that
+/// illusion.
+pub(crate) struct DualBuffer<'a, T: UnderlyingBuffer> {
+    buf: &'a mut T,
+    off: usize,
+
+    new_buf: &'a [u8],
+    new_buf_offset: usize,
+}
+
+impl<T: UnderlyingBuffer> core::ops::Index<usize> for DualBuffer<'_, T> {
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &u8 {
+        if self.off + index < self.buf.len() {
+            &self.buf[index + self.off]
+        } else {
+            &self.new_buf[self.new_buf_offset + index - (self.buf.len() - self.off)]
+        }
+    }
+}
+
+impl<'a, T: UnderlyingBuffer> DualBuffer<'a, T> {
+    pub(crate) fn new(buf: &'a mut T, new_buf: &'a [u8]) -> Self {
+        Self {
+            buf,
+            off: 0,
+            new_buf,
+            new_buf_offset: 0,
+        }
+    }
+
+    /// Clears all elements - equivalent to buf.drain(buf.len())
+    pub(crate) fn clear(&mut self) {
+        self.drain(self.len());
+    }
+
+    /// Remove count elements without providing a view into them.
+    pub(crate) fn drain(&mut self, count: usize) {
+        let underlying_bytes = core::cmp::min(self.buf.len() - self.off, count);
+        let new_bytes = count.saturating_sub(underlying_bytes);
+
+        self.off += underlying_bytes;
+        self.new_buf_offset += new_bytes;
+    }
+
+    /// Return the total number of accessible bytes in this view. Note that you may
+    /// not be able to take() this many bytes at once, if the total number of bytes
+    /// is more than the underlying store can fit.
+    pub(crate) fn len(&self) -> usize {
+        self.buf.len() - self.off + self.new_buf.len() - self.new_buf_offset
+    }
+
+    // Returns the number of bytes which would be lost (because they can't be copied into
+    // the underlying storage) if this DualBuffer were dropped.
+    pub(crate) fn potential_lost_bytes(&self) -> usize {
+        if self.len() <= self.buf.max_capacity() {
+            0
+        } else {
+            self.len() - self.buf.max_capacity()
+        }
+    }
+
+    pub(crate) fn can_drain_and_take(&self, drain: usize, take: usize) -> bool {
+        let underlying_bytes = core::cmp::min(self.buf.len() - self.off, drain);
+        let new_bytes = drain.saturating_sub(underlying_bytes);
+
+        let drained_off = self.off + underlying_bytes;
+        let drained_new_off = self.new_buf_offset + new_bytes;
+
+        if take > self.buf.len() - drained_off + self.new_buf.len() - drained_new_off {
+            // Draining removed too many bytes, we don't have enough to take
+            return false;
+        }
+
+        let underlying_bytes = core::cmp::min(self.buf.len() - drained_off, take);
+        let new_bytes = take.saturating_sub(underlying_bytes);
+
+        if underlying_bytes == 0 {
+            // We would take entirely from the new buffer
+            return true;
+        }
+
+        if new_bytes == 0 {
+            // We would take entirely from the underlying
+            return true;
+        }
+
+        if new_bytes > self.buf.max_capacity() - (self.buf.len() - drained_off) {
+            // We wouldn't be able to fit all the new bytes into underlying
+            return false;
+        }
+
+        true
+    }
+
+    pub(crate) fn peek_raw(&self, range: core::ops::Range<usize>) -> (&[u8], &[u8]) {
+        let split = self.buf.len() - self.off;
+        let a = if range.start >= split {
+            &[]
+        } else {
+            &self.buf[range.start + self.off..core::cmp::min(self.buf.len(), range.end + self.off)]
+        };
+        let b = if range.end <= split {
+            &[]
+        } else {
+            &self.new_buf[self.new_buf_offset + range.start.saturating_sub(split)
+                ..range.end - split + self.new_buf_offset]
+        };
+        (a, b)
+    }
+
+    /// Provide a view of the next count elements, moving data if necessary.
+    /// If the underlying store cannot store enough elements, no data is moved and an
+    /// error is returned.
+    pub(crate) fn take(&mut self, count: usize) -> Result<&[u8], ParserError> {
+        let underlying_bytes = core::cmp::min(self.buf.len() - self.off, count);
+        let new_bytes = count.saturating_sub(underlying_bytes);
+
+        if new_bytes > self.new_buf.len() - self.new_buf_offset {
+            // We need to pull more bytes from new than it has
+            panic!(
+                "Cannot pull {} bytes from a buffer with {}-{}",
+                new_bytes,
+                self.new_buf.len(),
+                self.new_buf_offset
+            );
+        }
+
+        if underlying_bytes == 0 {
+            // We can directly return a slice from new
+            let offset = self.new_buf_offset;
+            self.new_buf_offset += count;
+            return Ok(&self.new_buf[offset..offset + count]);
+        }
+
+        if new_bytes == 0 {
+            // We can directly return from underlying
+            let offset = self.off;
+            self.off += count;
+            return Ok(&self.buf[offset..offset + count]);
+        }
+
+        if self.buf.max_capacity() < count {
+            // Insufficient space
+            return Err(ParserError::OutOfMemory {
+                required_size: count,
+            });
+        }
+
+        if new_bytes < self.buf.max_capacity() - self.buf.len() {
+            // Underlying has enough space to extend from new
+            let bytes_not_moved = self
+                .buf
+                .extend_from_slice(&self.new_buf[self.new_buf_offset..]);
+            self.new_buf_offset += self.new_buf.len() - self.new_buf_offset - bytes_not_moved;
+            let off = self.off;
+            self.off += count;
+            return Ok(&self.buf[off..off + count]);
+        }
+
+        // Last case: We have to move the data in underlying, then extend it
+        self.buf.drain(self.off);
+        self.off = 0;
+        self.buf
+            .extend_from_slice(&self.new_buf[self.new_buf_offset..self.new_buf_offset + new_bytes]);
+        self.new_buf_offset += new_bytes;
+        self.off += count;
+        Ok(&self.buf[0..count])
+    }
+}
+
+impl<T: UnderlyingBuffer> Drop for DualBuffer<'_, T> {
+    fn drop(&mut self) {
+        self.buf.drain(self.off);
+        self.buf
+            .extend_from_slice(&self.new_buf[self.new_buf_offset..]);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[cfg(feature = "alloc")]
+    use alloc::vec;
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn dl_split_indexing() {
+        let mut buf = vec![1, 2, 3, 4];
+        let new = [5, 6, 7, 8];
+        let dual = DualBuffer::new(&mut buf, &new[..]);
+        for i in 0..8 {
+            assert_eq!(dual[i], i as u8 + 1);
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    #[should_panic]
+    fn dl_take_too_many() {
+        let mut buf = vec![1, 2, 3, 4];
+        let new = [];
+        {
+            let mut dual = DualBuffer::new(&mut buf, &new[..]);
+
+            // This should panic
+            let _ = dual.take(6);
+        }
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn dl_take_range_underlying() {
+        let mut buf = vec![1, 2, 3, 4];
+        let new = [];
+        {
+            let mut dual = DualBuffer::new(&mut buf, &new[..]);
+            let x = dual.take(3).unwrap();
+            assert_eq!(x, &[1, 2, 3]);
+        }
+        assert_eq!(buf, &[4]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn dl_take_range_new() {
+        let mut buf = vec![];
+        let new = [1, 2, 3, 4];
+        {
+            let mut dual = DualBuffer::new(&mut buf, &new[..]);
+            let x = dual.take(3).unwrap();
+            assert_eq!(x, &[1, 2, 3]);
+        }
+        assert_eq!(buf, &[4]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn dl_take_range_overlapping() {
+        let mut buf = vec![1, 2, 3, 4];
+        let new = [5, 6, 7, 8];
+        {
+            let mut dual = DualBuffer::new(&mut buf, &new[..]);
+            let x = dual.take(6).unwrap();
+            assert_eq!(x, &[1, 2, 3, 4, 5, 6]);
+        }
+        assert_eq!(buf, &[7, 8]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn dl_take_multi_ranges() {
+        let mut buf = vec![1, 2, 3, 4, 5, 6, 7];
+        let new = [8, 9, 10, 11, 12];
+        {
+            let mut dual = DualBuffer::new(&mut buf, &new[..]);
+            assert_eq!(dual.take(3).unwrap(), &[1, 2, 3]);
+            assert_eq!(dual.take(3).unwrap(), &[4, 5, 6]);
+            assert_eq!(dual.take(3).unwrap(), &[7, 8, 9]);
+            assert_eq!(dual.take(3).unwrap(), &[10, 11, 12]);
+        }
+        assert!(buf.is_empty());
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn dl_take_multi_ranges2() {
+        let mut buf = vec![1, 2, 3, 4, 5, 6, 7];
+        let new = [8, 9, 10, 11, 12];
+        {
+            let mut dual = DualBuffer::new(&mut buf, &new[..]);
+            assert_eq!(dual.take(3).unwrap(), &[1, 2, 3]);
+            assert_eq!(dual.take(6).unwrap(), &[4, 5, 6, 7, 8, 9]);
+        }
+        assert_eq!(buf, &[10, 11, 12]);
+    }
+
+    #[test]
+    fn dl_move_then_copy_fixed_lin_buf() {
+        let mut buf = [0; 7];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+        let new = [8, 9, 10, 11, 12];
+        {
+            let mut dual = DualBuffer::new(&mut buf, &new[..]);
+            assert_eq!(dual.take(3).unwrap(), &[1, 2, 3]);
+            assert_eq!(dual.take(6).unwrap(), &[4, 5, 6, 7, 8, 9]);
+        }
+        assert_eq!(buf.len(), 3);
+    }
+
+    #[test]
+    fn dl_move_then_copy_fixed_buf() {
+        let mut buf = FixedBuffer::<7>::new();
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+        let new = [8, 9, 10, 11, 12];
+        {
+            let mut dual = DualBuffer::new(&mut buf, &new[..]);
+            assert_eq!(dual.take(3).unwrap(), &[1, 2, 3]);
+            assert_eq!(dual.take(6).unwrap(), &[4, 5, 6, 7, 8, 9]);
+        }
+        assert_eq!(buf.len(), 3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn dl_take_range_oom() {
+        let mut buf = [0; 4];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        let new = [1, 2, 3, 4, 5, 6];
+
+        let mut dual = DualBuffer::new(&mut buf, &new[..]);
+        // This should throw
+        assert!(
+            matches!(dual.take(6), Err(ParserError::OutOfMemory { required_size }) if required_size == 6)
+        );
+    }
+
+    #[test]
+    fn dl_drain_partial_underlying() {
+        let mut buf = [0; 4];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3]);
+        let new = [4, 5, 6, 7, 8, 9];
+        let mut dual = DualBuffer::new(&mut buf, &new[..]);
+
+        dual.drain(2);
+        assert_eq!(dual.len(), 7);
+        assert_eq!(dual.take(4).unwrap(), &[3, 4, 5, 6]);
+        assert_eq!(dual.len(), 3);
+    }
+
+    #[test]
+    fn dl_drain() {
+        let mut buf = [0; 4];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3]);
+        let new = [4, 5, 6, 7, 8, 9];
+        let mut dual = DualBuffer::new(&mut buf, &new[..]);
+
+        dual.drain(5);
+        assert_eq!(dual.take(3).unwrap(), &[6, 7, 8]);
+        assert_eq!(dual.len(), 1);
+    }
+
+    #[test]
+    fn dl_clear() {
+        let mut buf = [0; 4];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3]);
+        let new = [4, 5, 6, 7, 8, 9];
+        let mut dual = DualBuffer::new(&mut buf, &new[..]);
+
+        assert_eq!(dual.len(), 9);
+        dual.clear();
+        assert_eq!(dual.len(), 0);
+    }
+
+    #[test]
+    fn dl_peek_raw() {
+        let mut buf = [0; 4];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3]);
+        let new = [4, 5, 6, 7, 8, 9];
+        let dual = DualBuffer::new(&mut buf, &new[..]);
+
+        let (a, b) = dual.peek_raw(2..6);
+        assert_eq!(a, &[3]);
+        assert_eq!(b, &[4, 5, 6]);
+    }
+
+    #[test]
+    fn flb_clear() {
+        let mut buf = [0; 16];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(buf.len(), 7);
+        buf.clear();
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn flb_index_outside_range() {
+        let mut buf = [0; 16];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+        let _ = buf[5..10];
+    }
+
+    #[test]
+    fn flb_extend_outside_range() {
+        let mut buf = [0; 16];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(buf.len(), 16);
+    }
+
+    #[test]
+    fn flb_drain() {
+        let mut buf = [0; 16];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+
+        buf.drain(3);
+        assert_eq!(buf.len(), 4);
+        assert_eq!(&buf[0..buf.len()], &[4, 5, 6, 7]);
+
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(buf.len(), 11);
+        assert_eq!(&buf[0..buf.len()], &[4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn flb_drain_all() {
+        let mut buf = [0; 16];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        buf.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7]);
+
+        buf.drain(7);
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn flb_find() {
+        let mut buf = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut buf = FixedLinearBuffer::new(&mut buf);
+        assert_eq!(buf.find(5), None);
+        buf.extend_from_slice(&[1, 2, 3, 4]);
+        assert_eq!(buf.find(5), None);
+        buf.extend_from_slice(&[5, 6, 7, 8]);
+        assert_eq!(buf.find(5), Some(4));
+    }
+}

--- a/ublox/src/proto17.rs
+++ b/ublox/src/proto17.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "ubx_proto14")]
+//! Protocol 17 specific types
+
+use crate::ubx_packets::packetref_proto17;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[doc(inline)]
+pub use crate::ubx_packets::packetref_proto17::PacketRef;
+
+impl<'a> From<PacketRef<'a>> for crate::UbxPacket<'a> {
+    fn from(packet: PacketRef<'a>) -> Self {
+        crate::UbxPacket::Proto17(packet)
+    }
+}
+
+/// Tag for protocol 17 packets
+pub struct Proto17;
+
+impl crate::UbxProtocol for Proto17 {
+    type PacketRef<'a> = PacketRef<'a>;
+    const MAX_PAYLOAD_LEN: usize = packetref_proto17::MAX_PAYLOAD_LEN as usize;
+
+    fn match_packet(
+        class_id: u8,
+        msg_id: u8,
+        payload: &[u8],
+    ) -> Result<Self::PacketRef<'_>, crate::ParserError> {
+        packetref_proto17::match_packet(class_id, msg_id, payload)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl core::default::Default for crate::Parser<Vec<u8>, Proto17> {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}

--- a/ublox/src/proto23.rs
+++ b/ublox/src/proto23.rs
@@ -1,0 +1,39 @@
+#![cfg(feature = "ubx_proto23")]
+//! Protocol 23 specific types
+
+use crate::ubx_packets::packetref_proto23;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[doc(inline)]
+pub use crate::ubx_packets::packetref_proto23::PacketRef;
+
+impl<'a> From<PacketRef<'a>> for crate::UbxPacket<'a> {
+    fn from(packet: PacketRef<'a>) -> Self {
+        crate::UbxPacket::Proto23(packet)
+    }
+}
+
+/// Tag for protocol 23 packets
+pub struct Proto23;
+
+impl crate::UbxProtocol for Proto23 {
+    type PacketRef<'a> = PacketRef<'a>;
+
+    const MAX_PAYLOAD_LEN: usize = packetref_proto23::MAX_PAYLOAD_LEN as usize;
+
+    fn match_packet(
+        class_id: u8,
+        msg_id: u8,
+        payload: &[u8],
+    ) -> Result<Self::PacketRef<'_>, crate::ParserError> {
+        packetref_proto23::match_packet(class_id, msg_id, payload)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl core::default::Default for crate::Parser<Vec<u8>, Proto23> {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}

--- a/ublox/src/proto27.rs
+++ b/ublox/src/proto27.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "ubx_proto27")]
+//! Protocol 27 specific types
+
+use crate::ubx_packets::packetref_proto27;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[doc(inline)]
+pub use crate::ubx_packets::packetref_proto27::PacketRef;
+
+impl<'a> From<PacketRef<'a>> for crate::UbxPacket<'a> {
+    fn from(packet: PacketRef<'a>) -> Self {
+        crate::UbxPacket::Proto27(packet)
+    }
+}
+
+/// Tag for protocol 27 packets
+pub struct Proto27;
+
+impl crate::UbxProtocol for Proto27 {
+    type PacketRef<'a> = PacketRef<'a>;
+    const MAX_PAYLOAD_LEN: usize = packetref_proto27::MAX_PAYLOAD_LEN as usize;
+
+    fn match_packet(
+        class_id: u8,
+        msg_id: u8,
+        payload: &[u8],
+    ) -> Result<Self::PacketRef<'_>, crate::ParserError> {
+        packetref_proto27::match_packet(class_id, msg_id, payload)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl core::default::Default for crate::Parser<Vec<u8>, Proto27> {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}

--- a/ublox/src/proto31.rs
+++ b/ublox/src/proto31.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "ubx_proto31")]
+//! Protocol 31 specific types
+
+use crate::ubx_packets::packetref_proto31;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+#[doc(inline)]
+pub use crate::ubx_packets::packetref_proto31::PacketRef;
+
+impl<'a> From<PacketRef<'a>> for crate::UbxPacket<'a> {
+    fn from(packet: PacketRef<'a>) -> Self {
+        crate::UbxPacket::Proto31(packet)
+    }
+}
+
+/// Tag for protocol 31 packets
+pub struct Proto31;
+
+impl crate::UbxProtocol for Proto31 {
+    type PacketRef<'a> = PacketRef<'a>;
+    const MAX_PAYLOAD_LEN: usize = packetref_proto31::MAX_PAYLOAD_LEN as usize;
+
+    fn match_packet(
+        class_id: u8,
+        msg_id: u8,
+        payload: &[u8],
+    ) -> Result<Self::PacketRef<'_>, crate::ParserError> {
+        packetref_proto31::match_packet(class_id, msg_id, payload)
+    }
+}
+
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl core::default::Default for crate::Parser<Vec<u8>, Proto31> {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}


### PR DESCRIPTION
- **divide top level protocol packet implementations into submodules**
- **add simple reading from serial device and parsing example**
- **allow running examples with specific features**
- **disable default features of serialport to avoid depending on udev**
- **remove obsolete libudev installation and avoid persisting credentials in checkout action**
- **only enable std and ubx_proto23 by default and instead introduce the 'full' feature to enable all features**
- **simplify basic-cli example by only handling one protocol at a time**
- **refactor examples, reduce duplication**
- **Buffer and docs improvements**
