### PR TITLE
NMEA packet (unparsed) extraction

### DIFF
--- a/ublox/src/lib.rs
+++ b/ublox/src/lib.rs
@@ -10,8 +10,8 @@ extern crate serde;
 pub use crate::{
     error::{DateTimeError, MemWriterError, ParserError},
     parser::{
-        AnyPacketRef, FixedBuffer, FixedLinearBuffer, Parser, ParserBuilder, RtcmPacketRef,
-        UbxParserIter, UnderlyingBuffer,
+        AnyPacketRef, FixedBuffer, FixedLinearBuffer, NmeaPacketRef, Parser, ParserBuilder,
+        RtcmPacketRef, UbxParserIter, UnderlyingBuffer,
     },
     ubx_packets::*,
 };

--- a/ublox/src/ubx_packets.rs
+++ b/ublox/src/ubx_packets.rs
@@ -17,6 +17,9 @@ pub trait UbxPacketMeta {
 pub(crate) const SYNC_CHAR_1: u8 = 0xb5;
 pub(crate) const SYNC_CHAR_2: u8 = 0x62;
 pub(crate) const RTCM_SYNC_CHAR: u8 = 0xd3;
+pub(crate) const NMEA_SYNC_CHAR: u8 = 0x24; // '$'
+pub(crate) const NMEA_END_CHAR_1: u8 = 0x0d; // '\r' (<CR>)
+pub(crate) const NMEA_END_CHAR_2: u8 = 0x0a; // '\n' (<LF>)
 
 /// The checksum is calculated over the packet, starting and including
 /// the CLASS field, up until, but excluding, the checksum field.


### PR DESCRIPTION
Add support to extract unparsed NMEA packets analogous to RTCM packet extraction (PR #125).
Since parsing has been split to UBX-only and UBX+RTCM, I did the same and added UBX+RTCM+NMEA. Thus keeping it backwards compatible. Though I personally think one parser for all would suffice and users could either configure the device to send only UBX packets or just ignore any returned RTCM/NMEA packets. Splitting it up currently results in unnecessary code duplication.