### PR TITLE
CFG-MSGOUT-UBX_ESF*, CFG-SF*, and dynamic models

### DIFF
--- a/ublox/src/ubx_packets/cfg_val.rs
+++ b/ublox/src/ubx_packets/cfg_val.rs
@@ -209,6 +209,12 @@ macro_rules! from_cfg_v_bytes {
             9 => NavDynamicModel::WristWornWatch,
             #[cfg(feature = "ubx_proto31")]
             10 => NavDynamicModel::Bike,
+            #[cfg(feature = "ubx_proto31")]
+            11 => NavDynamicModel::Mower,
+            #[cfg(feature = "ubx_proto31")]
+            12 => NavDynamicModel::EScooter,
+            #[cfg(feature = "ubx_proto31")]
+            13 => NavDynamicModel::Rail,
             _ => unreachable!(
                 "CFG-NAVSPG-DYNMODEL_TYPE value not supported by protocol specification"
             ),

--- a/ublox/src/ubx_packets/packets/cfg_nav5.rs
+++ b/ublox/src/ubx_packets/packets/cfg_nav5.rs
@@ -135,6 +135,12 @@ pub enum NavDynamicModel {
     #[cfg(feature = "ubx_proto31")]
     /// supported in protocol versions 19.2
     Bike = 10,
+    #[cfg(feature = "ubx_proto31")]
+    Mower = 11,
+    #[cfg(feature = "ubx_proto31")]
+    EScooter = 12,
+    #[cfg(feature = "ubx_proto31")]
+    Rail = 13,
 }
 
 /// Position Fixing Mode


### PR DESCRIPTION
Hi,
this adds support for some config keys/values (CFG-MSGOUT-UBX_ESF*, CFG-SF*) and dynamic models (mower, e-scooter, rail).