### PR TITLE
Fix request for MON-VER in basic-cli example

### DIFF
--- a/examples/basic-cli/src/main.rs
+++ b/examples/basic-cli/src/main.rs
@@ -1,6 +1,7 @@
 use ublox_device::ublox::{
     cfg_msg::{CfgMsgAllPorts, CfgMsgAllPortsBuilder},
-    nav_pvt, UbxPacket,
+    mon_ver::MonVer,
+    nav_pvt, UbxPacket, UbxPacketRequest,
 };
 
 /// Use proto23 if enabled, otherwise use proto27 if enabled, otherwise use proto31, otherwise use proto33, otherwise use proto14
@@ -61,7 +62,7 @@ fn main() {
 
     // Send a packet request for the MonVer packet
     device
-        .write_all(&cfg_msg_enable_nav_pvt_bytes())
+        .write_all(&UbxPacketRequest::request_for::<MonVer>().into_packet_bytes())
         .expect("Unable to write request/poll for UBX-MON-VER message");
 
     // Start reading data


### PR DESCRIPTION
The basic-cli example mistakenly sends a duplicate request for NAV-PVT instead of a request for MON-VER.
This change sends the correct request.

## To test:
Run the `basic-cli` example and observe the MON-VER outut.
 
 e.g.
 ```
 SW version: ROM CORE 4.04 (d964f4) HW version: 00190000; Extensions: ["FWVER=SPG 4.04", "PROTVER=32.01", "GPS;GLO;GAL;BDS", "SBAS;QZSS"]
MonVer { software_version: "ROM CORE 4.04 (d964f4)", hardware_version: "00190000", extension: MonVerExtensionIter { data: [70, 87, 86, 69, 82, 61, 83, 80, 71, 32, 52, 46, 48, 52, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 80, 82, 79, 84, 86, 69, 82, 61, 51, 50, 46, 48, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 71, 80, 83, 59, 71, 76, 79, 59, 71, 65, 76, 59, 66, 68, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 83, 66, 65, 83, 59, 81, 90, 83, 83, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], offset: 0 } }
```