### PR TITLE
Extract shared UBX fuzz-test helpers into tests/common

### DIFF
--- a/ublox/tests/common/mod.rs
+++ b/ublox/tests/common/mod.rs
@@ -1,0 +1,64 @@
+//! Shared helpers for the UBX packet fuzz tests.
+//!
+//! Keep this module minimal: only protocol-level primitives (checksum, frame
+//! envelope) and generic proptest strategies belong here. Per-packet payload
+//! structs and their `*_payload_strategy()` / `to_bytes()` helpers stay in
+//! their own test files so that each packet's correctness remains
+//! independently auditable.
+
+#![allow(dead_code)] // each test binary uses only a subset of these helpers
+
+use byteorder::{LittleEndian, WriteBytesExt};
+use proptest::prelude::*;
+use ublox::constants::{UBX_SYNC_CHAR_1, UBX_SYNC_CHAR_2};
+
+/// Calculates the 8-bit Fletcher-16 checksum used by U-Blox.
+///
+/// `data` is the checksummed region of the frame: class, id, length and
+/// payload (everything between the sync chars and the checksum bytes).
+pub fn calculate_checksum(data: &[u8]) -> (u8, u8) {
+    let mut ck_a: u8 = 0;
+    let mut ck_b: u8 = 0;
+    for byte in data {
+        ck_a = ck_a.wrapping_add(*byte);
+        ck_b = ck_b.wrapping_add(ck_a);
+    }
+    (ck_a, ck_b)
+}
+
+/// Assembles a complete, valid UBX frame from a class/id and payload:
+/// `[sync1, sync2, class, id, len_lo, len_hi, payload..., ck_a, ck_b]`.
+///
+/// The length field is the payload length as a little-endian `u16`, and the
+/// checksum is computed over `class..=payload` per [`calculate_checksum`].
+pub fn build_ubx_frame(class: u8, id: u8, payload: &[u8]) -> Vec<u8> {
+    let mut frame_core = Vec::with_capacity(4 + payload.len());
+    frame_core.push(class);
+    frame_core.push(id);
+    frame_core
+        .write_u16::<LittleEndian>(payload.len() as u16)
+        .unwrap();
+    frame_core.extend_from_slice(payload);
+
+    let (ck_a, ck_b) = calculate_checksum(&frame_core);
+
+    let mut frame = Vec::with_capacity(8 + payload.len());
+    frame.push(UBX_SYNC_CHAR_1);
+    frame.push(UBX_SYNC_CHAR_2);
+    frame.extend_from_slice(&frame_core);
+    frame.push(ck_a);
+    frame.push(ck_b);
+    frame
+}
+
+/// A proptest strategy that generates only finite `f32` values (no NaN/inf).
+pub fn finite_f32() -> impl Strategy<Value = f32> {
+    any::<u32>().prop_filter_map("finite f32", |bits| {
+        let f = f32::from_bits(bits);
+        if f.is_finite() {
+            Some(f)
+        } else {
+            None
+        }
+    })
+}

--- a/ublox/tests/fuzz_mon_comms.rs
+++ b/ublox/tests/fuzz_mon_comms.rs
@@ -13,7 +13,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents a single 40-byte port block within a MON-COMMS message.
 #[derive(Debug, Clone)]
@@ -81,17 +84,6 @@ impl MonCommsPayload {
         }
         wtr
     }
-}
-
-/// Calculates the 8-bit Fletcher-16 checksum used by u-blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
 }
 
 fn port_id_strategy() -> impl Strategy<Value = u16> {
@@ -193,24 +185,7 @@ fn mon_comms_payload_strategy() -> impl Strategy<Value = MonCommsPayload> {
 pub fn ubx_mon_comms_frame_strategy() -> impl Strategy<Value = (MonCommsPayload, Vec<u8>)> {
     mon_comms_payload_strategy().prop_map(|payload_struct| {
         let payload = payload_struct.to_bytes();
-        let class_id = 0x0A;
-        let message_id = 0x36;
-        let length = payload.len() as u16;
-
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0A, 0x36, &payload);
 
         (payload_struct, final_frame)
     })

--- a/ublox/tests/fuzz_mon_hw2.rs
+++ b/ublox/tests/fuzz_mon_hw2.rs
@@ -14,10 +14,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{
-    constants::{UBX_SYNC_CHAR_1, UBX_SYNC_CHAR_2},
-    ParserBuilder, UbxPacket,
-};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents the payload of a UBX-MON-HW2 message.
 ///
@@ -107,17 +107,6 @@ pub fn mon_hw2_payload_strategy() -> impl Strategy<Value = MonHw2> {
         )
 }
 
-/// Calculates the 8-bit Fletcher-16 checksum used by U-Blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 /// A proptest strategy that generates a complete, valid UBX frame
 /// containing a MON-HW2 message, along with the source `MonHw2` struct.
 ///
@@ -126,26 +115,7 @@ fn calculate_checksum(data: &[u8]) -> (u8, u8) {
 pub fn ubx_mon_hw2_frame_strategy() -> impl Strategy<Value = (MonHw2, Vec<u8>)> {
     mon_hw2_payload_strategy().prop_map(|mon_hw2| {
         let payload = mon_hw2.to_bytes();
-        let class_id = 0x0A; // MON class
-        let message_id = 0x0B; // HW2 message ID
-        let length = payload.len() as u16;
-
-        // Start building the frame to be checksummed
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        // Assemble the final frame
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0A, 0x0B, &payload);
 
         (mon_hw2, final_frame)
     })

--- a/ublox/tests/fuzz_mon_hw3.rs
+++ b/ublox/tests/fuzz_mon_hw3.rs
@@ -13,10 +13,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{
-    constants::{UBX_SYNC_CHAR_1, UBX_SYNC_CHAR_2},
-    ParserBuilder, UbxPacket,
-};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents a single pin in the UBX-MON-HW3 message.
 #[derive(Debug, Clone)]
@@ -61,17 +61,6 @@ impl MonHw3 {
 
         wtr
     }
-}
-
-/// Calculates the 8-bit Fletcher-16 checksum used by U-Blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
 }
 
 fn hw_version_strategy() -> impl Strategy<Value = [u8; 10]> {
@@ -126,26 +115,7 @@ pub fn mon_hw3_payload_strategy() -> impl Strategy<Value = MonHw3> {
 pub fn ubx_mon_hw3_frame_strategy() -> impl Strategy<Value = (MonHw3, Vec<u8>)> {
     mon_hw3_payload_strategy().prop_map(|mon_hw3| {
         let payload = mon_hw3.to_bytes();
-        let class_id = 0x0A;
-        let message_id = 0x37;
-        let length = payload.len() as u16;
-
-        // Build the frame core
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        // Assemble final frame
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0A, 0x37, &payload);
 
         (mon_hw3, final_frame)
     })

--- a/ublox/tests/fuzz_mon_io.rs
+++ b/ublox/tests/fuzz_mon_io.rs
@@ -7,7 +7,8 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::constants::{UBX_SYNC_CHAR_1, UBX_SYNC_CHAR_2};
+mod common;
+use common::build_ubx_frame;
 
 /// Represents a single I/O port block in a MON-IO message (20 bytes).
 #[derive(Debug, Clone)]
@@ -76,17 +77,6 @@ fn mon_io_payload_strategy() -> impl Strategy<Value = Vec<MonIoPort>> {
     prop::collection::vec(mon_io_port_strategy(), 1..=6)
 }
 
-/// Calculates the 8-bit Fletcher-16 checksum used by U-Blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 /// A proptest strategy that generates a complete, valid UBX frame
 /// containing a MON-IO message, along with the source port data.
 ///
@@ -99,26 +89,7 @@ pub fn ubx_mon_io_frame_strategy() -> impl Strategy<Value = (Vec<MonIoPort>, Vec
             payload.extend_from_slice(&port.to_bytes());
         }
 
-        let class_id = 0x0a;
-        let message_id = 0x02;
-        let length = payload.len() as u16;
-
-        // Build the frame core (class, id, length, payload)
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        // Assemble the final frame
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0a, 0x02, &payload);
 
         (ports, final_frame)
     })

--- a/ublox/tests/fuzz_mon_msgpp.rs
+++ b/ublox/tests/fuzz_mon_msgpp.rs
@@ -7,7 +7,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Number of I/O ports
 const NUM_PORTS: usize = 6;
@@ -48,43 +51,12 @@ fn mon_msgpp_payload_strategy() -> impl Strategy<Value = MonMsgppPayload> {
         .prop_map(|(msg, skipped)| MonMsgppPayload { msg, skipped })
 }
 
-/// Calculates the 8-bit Fletcher-16 checksum used by U-Blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 /// A proptest strategy that generates a complete, valid UBX frame
 /// containing a MON-MSGPP message, along with the source payload data.
 pub fn ubx_mon_msgpp_frame_strategy() -> impl Strategy<Value = (MonMsgppPayload, Vec<u8>)> {
     mon_msgpp_payload_strategy().prop_map(|payload_data| {
         let payload = payload_data.to_bytes();
-
-        let class_id = 0x0a;
-        let message_id = 0x06;
-        let length = payload.len() as u16;
-
-        // Build the frame core (class, id, length, payload)
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        // Assemble the final frame
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0a, 0x06, &payload);
 
         (payload_data, final_frame)
     })

--- a/ublox/tests/fuzz_mon_patch.rs
+++ b/ublox/tests/fuzz_mon_patch.rs
@@ -2,7 +2,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 #[derive(Debug, Clone)]
 pub struct MonPatchEntry {
@@ -62,38 +65,11 @@ fn mon_patch_payload_strategy() -> impl Strategy<Value = MonPatchPayload> {
         .prop_map(|(version, entries)| MonPatchPayload { version, entries })
 }
 
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 pub fn ubx_mon_patch_frame_strategy() -> impl Strategy<Value = (MonPatchPayload, Vec<u8>)> {
     mon_patch_payload_strategy().prop_map(|payload_data| {
         let payload = payload_data.to_bytes();
 
-        let class_id = 0x0a;
-        let message_id = 0x27;
-        let length = payload.len() as u16;
-
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0a, 0x27, &payload);
 
         (payload_data, final_frame)
     })

--- a/ublox/tests/fuzz_mon_rf.rs
+++ b/ublox/tests/fuzz_mon_rf.rs
@@ -14,10 +14,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{
-    constants::{UBX_SYNC_CHAR_1, UBX_SYNC_CHAR_2},
-    ParserBuilder, UbxPacket,
-};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents a single RF block within a MON-RF message payload.
 ///
@@ -148,40 +148,13 @@ pub fn mon_rf_payload_strategy() -> impl Strategy<Value = MonRf> {
         })
 }
 
-/// Calculates the 8-bit Fletcher-16 checksum used by U-Blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 /// A proptest strategy that generates a complete, valid UBX frame
 /// containing a MON-RF message, along with the source `MonRf` struct.
 pub fn ubx_mon_rf_frame_strategy() -> impl Strategy<Value = (MonRf, Vec<u8>)> {
     mon_rf_payload_strategy().prop_map(|mon_rf| {
         let payload = mon_rf.to_bytes();
-        let class_id = 0x0A; // MON class
-        let message_id = 0x38; // RF message ID
-        let length = payload.len() as u16;
 
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0A, 0x38, &payload);
 
         (mon_rf, final_frame)
     })

--- a/ublox/tests/fuzz_mon_rxbuf.rs
+++ b/ublox/tests/fuzz_mon_rxbuf.rs
@@ -2,7 +2,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 const NUM_TARGETS: usize = 6;
 
@@ -38,38 +41,11 @@ fn mon_rxbuf_payload_strategy() -> impl Strategy<Value = MonRxbufPayload> {
         })
 }
 
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 pub fn ubx_mon_rxbuf_frame_strategy() -> impl Strategy<Value = (MonRxbufPayload, Vec<u8>)> {
     mon_rxbuf_payload_strategy().prop_map(|payload_data| {
         let payload = payload_data.to_bytes();
 
-        let class_id = 0x0a;
-        let message_id = 0x07;
-        let length = payload.len() as u16;
-
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0a, 0x07, &payload);
 
         (payload_data, final_frame)
     })

--- a/ublox/tests/fuzz_mon_rxr.rs
+++ b/ublox/tests/fuzz_mon_rxr.rs
@@ -3,9 +3,11 @@
 //! This module provides a `proptest` strategy to generate byte-level
 //! UBX frames containing a MON-RXR message.
 
-use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents the MON-RXR payload (1 byte).
 #[derive(Debug, Clone)]
@@ -19,41 +21,13 @@ impl MonRxrPayload {
     }
 }
 
-/// Calculates the 8-bit Fletcher-16 checksum used by U-Blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 /// A proptest strategy that generates a complete, valid UBX frame
 /// containing a MON-RXR message.
 pub fn ubx_mon_rxr_frame_strategy() -> impl Strategy<Value = (MonRxrPayload, Vec<u8>)> {
     any::<u8>().prop_map(|flags| {
         let payload_data = MonRxrPayload { flags };
 
-        let class_id = 0x0a;
-        let message_id = 0x21;
-        let length: u16 = 1;
-
-        let mut frame_core = Vec::with_capacity(5);
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.push(flags);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(9);
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0a, 0x21, &[flags]);
 
         (payload_data, final_frame)
     })

--- a/ublox/tests/fuzz_mon_span.rs
+++ b/ublox/tests/fuzz_mon_span.rs
@@ -2,7 +2,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 const SPECTRUM_SIZE: usize = 256;
 
@@ -94,38 +97,11 @@ fn mon_span_payload_strategy() -> impl Strategy<Value = MonSpanPayload> {
         })
 }
 
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 pub fn ubx_mon_span_frame_strategy() -> impl Strategy<Value = (MonSpanPayload, Vec<u8>)> {
     mon_span_payload_strategy().prop_map(|payload_data| {
         let payload = payload_data.to_bytes();
 
-        let class_id = 0x0a;
-        let message_id = 0x31;
-        let length = payload.len() as u16;
-
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0a, 0x31, &payload);
 
         (payload_data, final_frame)
     })

--- a/ublox/tests/fuzz_mon_txbuf.rs
+++ b/ublox/tests/fuzz_mon_txbuf.rs
@@ -2,7 +2,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 const NUM_TARGETS: usize = 6;
 
@@ -58,38 +61,11 @@ fn mon_txbuf_payload_strategy() -> impl Strategy<Value = MonTxbufPayload> {
         )
 }
 
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 pub fn ubx_mon_txbuf_frame_strategy() -> impl Strategy<Value = (MonTxbufPayload, Vec<u8>)> {
     mon_txbuf_payload_strategy().prop_map(|payload_data| {
         let payload = payload_data.to_bytes();
 
-        let class_id = 0x0a;
-        let message_id = 0x08;
-        let length = payload.len() as u16;
-
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x0a, 0x08, &payload);
 
         (payload_data, final_frame)
     })

--- a/ublox/tests/fuzz_nav_cov.rs
+++ b/ublox/tests/fuzz_nav_cov.rs
@@ -13,7 +13,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::{build_ubx_frame, finite_f32};
 
 /// Represents the payload of a UBX-NAV-COV message.
 ///
@@ -66,29 +69,6 @@ impl NavCovPayload {
         wtr.write_f32::<LittleEndian>(self.vel_cov_dd).unwrap();
         wtr
     }
-}
-
-/// Calculates the 8-bit Fletcher-16 checksum used by u-blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
-/// Generates finite `f32` values (excludes NaN and +/-Inf).
-fn finite_f32() -> impl Strategy<Value = f32> {
-    any::<u32>().prop_filter_map("finite f32", |bits| {
-        let f = f32::from_bits(bits);
-        if f.is_finite() {
-            Some(f)
-        } else {
-            None
-        }
-    })
 }
 
 /// A proptest strategy for generating a `NavCovPayload` struct.
@@ -157,24 +137,8 @@ fn nav_cov_payload_strategy() -> impl Strategy<Value = NavCovPayload> {
 pub fn ubx_nav_cov_frame_strategy() -> impl Strategy<Value = (NavCovPayload, Vec<u8>)> {
     nav_cov_payload_strategy().prop_map(|payload_struct| {
         let payload = payload_struct.to_bytes();
-        let class_id = 0x01;
-        let message_id = 0x36;
-        let length = payload.len() as u16;
 
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x01, 0x36, &payload);
 
         (payload_struct, final_frame)
     })

--- a/ublox/tests/fuzz_nav_hp_pos_llh.rs
+++ b/ublox/tests/fuzz_nav_hp_pos_llh.rs
@@ -7,10 +7,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{
-    constants::{UBX_SYNC_CHAR_1, UBX_SYNC_CHAR_2},
-    ParserBuilder, UbxPacket,
-};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 #[allow(dead_code, reason = "dead variants for SOME feature flag combination")]
 #[derive(Debug, Clone, Copy)]
@@ -137,17 +137,6 @@ pub fn nav_hpposllh_payload_strategy(
         )
 }
 
-/// Calculates the 8-bit Fletcher-16 checksum used by U-Blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 /// A proptest strategy that generates a complete, valid UBX frame
 /// containing a NAV-HPPOSLLH message, along with the source `NavHpPosLlh` struct.
 ///
@@ -158,26 +147,8 @@ pub fn ubx_nav_hpposllh_frame_strategy(
 ) -> impl Strategy<Value = (NavHpPosLlh, Vec<u8>)> {
     nav_hpposllh_payload_strategy(version).prop_map(move |nav_hpposllh| {
         let payload = nav_hpposllh.to_bytes(version);
-        let class_id = 0x01; // NAV class
-        let message_id = 0x14; // HPPOSLLH message ID
-        let length = payload.len() as u16;
 
-        // Start building the frame to be checksummed
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        // Assemble the final frame
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x01, 0x14, &payload);
 
         (nav_hpposllh, final_frame)
     })

--- a/ublox/tests/fuzz_nav_pl.rs
+++ b/ublox/tests/fuzz_nav_pl.rs
@@ -13,7 +13,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents the payload of a UBX-NAV-PL message.
 ///
@@ -76,17 +79,6 @@ impl NavPlPayload {
         wtr.extend_from_slice(&self.reserved1);
         wtr
     }
-}
-
-/// Calculates the 8-bit Fletcher-16 checksum used by u-blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
 }
 
 /// A proptest strategy for generating a `NavPlPayload` struct.
@@ -193,24 +185,8 @@ fn nav_pl_payload_strategy() -> impl Strategy<Value = NavPlPayload> {
 pub fn ubx_nav_pl_frame_strategy() -> impl Strategy<Value = (NavPlPayload, Vec<u8>)> {
     nav_pl_payload_strategy().prop_map(|payload_struct| {
         let payload = payload_struct.to_bytes();
-        let class_id = 0x01;
-        let message_id = 0x62;
-        let length = payload.len() as u16;
 
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x01, 0x62, &payload);
 
         (payload_struct, final_frame)
     })

--- a/ublox/tests/fuzz_nav_pos_ecef.rs
+++ b/ublox/tests/fuzz_nav_pos_ecef.rs
@@ -13,7 +13,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents the payload of a UBX-NAV-POSECEF message.
 ///
@@ -44,17 +47,6 @@ impl NavPosEcefPayload {
     }
 }
 
-/// Calculates the 8-bit Fletcher-16 checksum used by u-blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 /// A proptest strategy for generating a `NavPosEcefPayload` struct.
 fn nav_pos_ecef_payload_strategy() -> impl Strategy<Value = NavPosEcefPayload> {
     (
@@ -81,24 +73,8 @@ fn nav_pos_ecef_payload_strategy() -> impl Strategy<Value = NavPosEcefPayload> {
 pub fn ubx_nav_pos_ecef_frame_strategy() -> impl Strategy<Value = (NavPosEcefPayload, Vec<u8>)> {
     nav_pos_ecef_payload_strategy().prop_map(|payload_struct| {
         let payload = payload_struct.to_bytes();
-        let class_id = 0x01;
-        let message_id = 0x01;
-        let length = payload.len() as u16;
 
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x01, 0x01, &payload);
 
         (payload_struct, final_frame)
     })

--- a/ublox/tests/fuzz_nav_pvt.rs
+++ b/ublox/tests/fuzz_nav_pvt.rs
@@ -7,10 +7,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{
-    constants::{UBX_SYNC_CHAR_1, UBX_SYNC_CHAR_2},
-    ParserBuilder, UbxPacket,
-};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 #[allow(dead_code, reason = "dead variants for SOME feature flag combination")]
 #[derive(Debug, Clone, Copy)]
@@ -260,17 +260,6 @@ pub fn nav_pvt_payload_strategy(version: ProtocolVersion) -> impl Strategy<Value
     )
 }
 
-/// Calculates the 8-bit Fletcher-16 checksum used by U-Blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 /// A proptest strategy that generates a complete, valid UBX frame
 /// containing a NAV-PVT message, along with the source `NavPvt` struct.
 ///
@@ -281,26 +270,7 @@ pub fn ubx_nav_pvt_frame_strategy(
 ) -> impl Strategy<Value = (NavPvt, Vec<u8>)> {
     nav_pvt_payload_strategy(version).prop_map(move |nav_pvt| {
         let payload = nav_pvt.to_bytes(version);
-        let class_id = 0x01;
-        let message_id = 0x07;
-        let length = payload.len() as u16;
-
-        // Start building the frame to be checksummed
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        // Assemble the final frame
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x01, 0x07, &payload);
 
         (nav_pvt, final_frame)
     })

--- a/ublox/tests/fuzz_rxm_cor.rs
+++ b/ublox/tests/fuzz_rxm_cor.rs
@@ -13,7 +13,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{constants::UBX_SYNC_CHAR_1, constants::UBX_SYNC_CHAR_2, ParserBuilder, UbxPacket};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents the payload of a UBX-RXM-COR message.
 ///
@@ -40,17 +43,6 @@ impl RxmCorPayload {
         wtr.write_u16::<LittleEndian>(self.msg_sub_type).unwrap();
         wtr
     }
-}
-
-/// Calculates the 8-bit Fletcher-16 checksum used by u-blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
 }
 
 /// A proptest strategy for generating a `RxmCorPayload` struct.
@@ -80,24 +72,7 @@ fn rxm_cor_payload_strategy() -> impl Strategy<Value = RxmCorPayload> {
 pub fn ubx_rxm_cor_frame_strategy() -> impl Strategy<Value = (RxmCorPayload, Vec<u8>)> {
     rxm_cor_payload_strategy().prop_map(|payload_struct| {
         let payload = payload_struct.to_bytes();
-        let class_id = 0x02;
-        let message_id = 0x34;
-        let length = payload.len() as u16;
-
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x02, 0x34, &payload);
 
         (payload_struct, final_frame)
     })

--- a/ublox/tests/fuzz_sec_sig.rs
+++ b/ublox/tests/fuzz_sec_sig.rs
@@ -13,10 +13,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{
-    constants::{UBX_SYNC_CHAR_1, UBX_SYNC_CHAR_2},
-    ParserBuilder, UbxPacket,
-};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents the payload of a UBX-SEC-SIG message.
 ///
@@ -48,17 +48,6 @@ impl SecSigPayload {
         }
         wtr
     }
-}
-
-/// Calculates the 8-bit Fletcher-16 checksum used by u-blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
 }
 
 /// A proptest strategy for generating a `SecSigPayload` struct.
@@ -93,24 +82,7 @@ fn sec_sig_payload_strategy() -> impl Strategy<Value = SecSigPayload> {
 pub fn ubx_sec_sig_frame_strategy() -> impl Strategy<Value = (SecSigPayload, Vec<u8>)> {
     sec_sig_payload_strategy().prop_map(|payload_struct| {
         let payload = payload_struct.to_bytes();
-        let class_id = 0x27;
-        let message_id = 0x09;
-        let length = payload.len() as u16;
-
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x27, 0x09, &payload);
 
         (payload_struct, final_frame)
     })

--- a/ublox/tests/fuzz_sec_siglog.rs
+++ b/ublox/tests/fuzz_sec_siglog.rs
@@ -13,10 +13,10 @@
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use proptest::prelude::*;
-use ublox::{
-    constants::{UBX_SYNC_CHAR_1, UBX_SYNC_CHAR_2},
-    ParserBuilder, UbxPacket,
-};
+use ublox::{ParserBuilder, UbxPacket};
+
+mod common;
+use common::build_ubx_frame;
 
 /// Represents a single 8-byte event entry within a SEC-SIGLOG message.
 #[derive(Debug, Clone)]
@@ -60,17 +60,6 @@ impl SecSiglogPayload {
     }
 }
 
-/// Calculates the 8-bit Fletcher-16 checksum used by u-blox.
-fn calculate_checksum(data: &[u8]) -> (u8, u8) {
-    let mut ck_a: u8 = 0;
-    let mut ck_b: u8 = 0;
-    for byte in data {
-        ck_a = ck_a.wrapping_add(*byte);
-        ck_b = ck_b.wrapping_add(ck_a);
-    }
-    (ck_a, ck_b)
-}
-
 /// A proptest strategy for generating a single `SecSiglogEventPayload`.
 fn sec_siglog_event_strategy() -> impl Strategy<Value = SecSiglogEventPayload> {
     (any::<u32>(), any::<u8>(), any::<u8>()).prop_map(
@@ -105,24 +94,7 @@ fn sec_siglog_payload_strategy() -> impl Strategy<Value = SecSiglogPayload> {
 pub fn ubx_sec_siglog_frame_strategy() -> impl Strategy<Value = (SecSiglogPayload, Vec<u8>)> {
     sec_siglog_payload_strategy().prop_map(|payload_struct| {
         let payload = payload_struct.to_bytes();
-        let class_id = 0x27;
-        let message_id = 0x10;
-        let length = payload.len() as u16;
-
-        let mut frame_core = Vec::with_capacity(4 + payload.len());
-        frame_core.push(class_id);
-        frame_core.push(message_id);
-        frame_core.write_u16::<LittleEndian>(length).unwrap();
-        frame_core.extend_from_slice(&payload);
-
-        let (ck_a, ck_b) = calculate_checksum(&frame_core);
-
-        let mut final_frame = Vec::with_capacity(8 + payload.len());
-        final_frame.push(UBX_SYNC_CHAR_1);
-        final_frame.push(UBX_SYNC_CHAR_2);
-        final_frame.extend_from_slice(&frame_core);
-        final_frame.push(ck_a);
-        final_frame.push(ck_b);
+        let final_frame = build_ubx_frame(0x27, 0x10, &payload);
 
         (payload_struct, final_frame)
     })

--- a/ublox/tests/lib.rs
+++ b/ublox/tests/lib.rs
@@ -3,9 +3,4 @@ mod parser_binary_dump_test;
 mod parser_tests;
 mod rxm_sfrbx;
 
-mod fuzz_mon_hw2;
-mod fuzz_mon_hw3;
-mod fuzz_mon_rf;
-
-mod fuzz_nav_hp_pos_llh;
-mod fuzz_nav_pvt;
+// `fuzz_*` tests are their own auto-discovered binaries; don't declare them here.


### PR DESCRIPTION
Per the discussion on #188, this extracts the duplicated boilerplate from the
existing proptest fuzz tests into a shared module, so adding fuzz coverage
for more packets is cheap without generating any verification code from 
the design code.

## Changes

- **New `ublox/tests/common/mod.rs`** with the protocol-level primitives that
  were copy-pasted across every fuzz file:
  - `calculate_checksum()`  Fletcher-16 over class/id/len/payload
  - `build_ubx_frame(class, id, payload)`  full sync + header + payload + checksum
  - `finite_f32()`  proptest strategy excluding NaN/inf
- **All 19 `fuzz_*.rs`** now call `build_ubx_frame()` instead of hand-rolling
  the frame, and drop their local `calculate_checksum()` (and `finite_f32()`
  in `fuzz_nav_cov.rs`).
- **`ublox/tests/lib.rs`**  removed 5 redundant `mod fuzz_*;` declarations.
  Each `tests/*.rs` is already its own auto-discovered test binary, so those
  were double-compiled, and the redeclaration would collide with the new
  `mod common;` path resolution.

Net **-451 lines** (+166 / -617).

## Keeping tests auditable

To address the concern about making it hard to accidentally weaken a suite,
the shared module is deliberately limited to obviously-correct, protocol-level
primitives. Per-packet payload structs and their `*_payload_strategy()` /
`to_bytes()` helpers stay in their own files, so each packet's correctness
remains independently reviewable.

## Verification

- `cargo test -p ublox --features full`  all 25 test binaries pass. Every
  generated frame is fed through the real parser (which validates the
  checksum/envelope), so this confirms `build_ubx_frame` is byte-identical to
  the old inline logic.
- `cargo clippy -p ublox --features full --tests` is clean.

## Notes

Opened as a draft. This is the enabling refactor; coverage is currently 19 of
58 `#[ubx_packet_recv]` packets, and the remaining ~39 become cheap follow-ups
on top of `build_ubx_frame`. Happy to adjust the module's shape or split this
differently if you'd prefer.