### PR TITLE
Add L5/L6 CFG-SIGNAL keys and NavIC constellation support

### DIFF
--- a/ublox/src/ubx_packets/cfg_val.rs
+++ b/ublox/src/ubx_packets/cfg_val.rs
@@ -1423,18 +1423,27 @@ cfg_val! {
   SignalGpsEna,          0x1031001f, bool,
   SignalGpsL1caEna,      0x10310001, bool,
   SignalGpsL2cEna,       0x10310003, bool,
+  SignalGpsL5Ena,        0x10310004, bool,
   SignalGalEna,          0x10310021, bool,
   SignalGalE1Ena,        0x10310007, bool,
   SignalGalE5bEna,       0x1031000a, bool,
+  SignalGalE5aEna,       0x10310009, bool,
+  SignalGalE6Ena,        0x1031000b, bool,
   SignalBdsEna,          0x10310022, bool,
   SignalBdsB1Ena,        0x1031000d, bool,
   SignalBdsB2Ena,        0x1031000e, bool,
+  SignalBdsB1cEna,       0x1031000f, bool,
+  SignalBdsB2aEna,       0x10310028, bool,
+  SignalBdsB3Ena,        0x10310010, bool,
   SignalQzssEna,         0x10310024, bool,
   SignalQzssL1caEna,     0x10310012, bool,
   SignalQzssL2cEna,      0x10310015, bool,
+  SignalQzssL5Ena,       0x10310017, bool,
   SignalGloEna,          0x10310025, bool,
   SignalGloL1Ena,        0x10310018, bool,
   SignalGLoL2Ena,        0x1031001a, bool,
+  SignalNavicEna,        0x10310026, bool,
+  SignalNavicL5Ena,      0x1031001d, bool,
 
   /// "Undocumented" L5 Health Bit Ignore (see
   /// <https://content.u-blox.com/sites/default/files/documents/GPS-L5-configuration_AppNote_UBX-21038688.pdf>)
@@ -1748,4 +1757,97 @@ pub enum TModePosType {
     ECEF = 0,
     /// Lat/Lon/Height position
     LLH = 1,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: encode a bool-valued CFG key via `write_to`, assert the
+    /// 4-byte little-endian key ID and the 1-byte value, then round-trip
+    /// through `CfgVal::parse` and check the resulting key matches.
+    fn assert_bool_key(val: CfgVal, key_id: u32, value_byte: u8) {
+        let mut buf = [0u8; 5];
+        let written = val.write_to(&mut buf);
+        assert_eq!(written, 5, "bool CFG key+value must encode to 5 bytes");
+        assert_eq!(
+            &buf[..4],
+            &key_id.to_le_bytes()[..],
+            "key ID little-endian mismatch"
+        );
+        assert_eq!(buf[4], value_byte, "value byte mismatch");
+
+        // Round-trip via parse().
+        let parsed = CfgVal::parse(&buf).expect("parse should succeed");
+        assert_eq!(parsed, val, "round-tripped CfgVal mismatch");
+        assert_eq!(parsed.key() as u32, key_id, "round-tripped key mismatch");
+    }
+
+    #[test]
+    fn signal_gps_l5_ena_encodes_correctly() {
+        assert_bool_key(CfgVal::SignalGpsL5Ena(true), 0x10310004, 1);
+        assert_bool_key(CfgVal::SignalGpsL5Ena(false), 0x10310004, 0);
+    }
+
+    #[test]
+    fn signal_gal_e5a_ena_encodes_correctly() {
+        assert_bool_key(CfgVal::SignalGalE5aEna(true), 0x10310009, 1);
+        assert_bool_key(CfgVal::SignalGalE5aEna(false), 0x10310009, 0);
+    }
+
+    #[test]
+    fn signal_gal_e6_ena_encodes_correctly() {
+        assert_bool_key(CfgVal::SignalGalE6Ena(true), 0x1031000b, 1);
+        assert_bool_key(CfgVal::SignalGalE6Ena(false), 0x1031000b, 0);
+    }
+
+    #[test]
+    fn signal_bds_b1c_ena_encodes_correctly() {
+        assert_bool_key(CfgVal::SignalBdsB1cEna(true), 0x1031000f, 1);
+        assert_bool_key(CfgVal::SignalBdsB1cEna(false), 0x1031000f, 0);
+    }
+
+    #[test]
+    fn signal_bds_b2a_ena_encodes_correctly() {
+        assert_bool_key(CfgVal::SignalBdsB2aEna(true), 0x10310028, 1);
+        assert_bool_key(CfgVal::SignalBdsB2aEna(false), 0x10310028, 0);
+    }
+
+    #[test]
+    fn signal_bds_b3_ena_encodes_correctly() {
+        assert_bool_key(CfgVal::SignalBdsB3Ena(true), 0x10310010, 1);
+        assert_bool_key(CfgVal::SignalBdsB3Ena(false), 0x10310010, 0);
+    }
+
+    #[test]
+    fn signal_qzss_l5_ena_encodes_correctly() {
+        assert_bool_key(CfgVal::SignalQzssL5Ena(true), 0x10310017, 1);
+        assert_bool_key(CfgVal::SignalQzssL5Ena(false), 0x10310017, 0);
+    }
+
+    #[test]
+    fn signal_navic_ena_encodes_correctly() {
+        assert_bool_key(CfgVal::SignalNavicEna(true), 0x10310026, 1);
+        assert_bool_key(CfgVal::SignalNavicEna(false), 0x10310026, 0);
+    }
+
+    #[test]
+    fn signal_navic_l5_ena_encodes_correctly() {
+        assert_bool_key(CfgVal::SignalNavicL5Ena(true), 0x1031001d, 1);
+        assert_bool_key(CfgVal::SignalNavicL5Ena(false), 0x1031001d, 0);
+    }
+
+    #[test]
+    fn new_signal_keys_have_expected_key_ids() {
+        // Sanity check the key-ID discriminants line up with the ICD.
+        assert_eq!(CfgKey::SignalGpsL5Ena as u32, 0x10310004);
+        assert_eq!(CfgKey::SignalGalE5aEna as u32, 0x10310009);
+        assert_eq!(CfgKey::SignalGalE6Ena as u32, 0x1031000b);
+        assert_eq!(CfgKey::SignalBdsB1cEna as u32, 0x1031000f);
+        assert_eq!(CfgKey::SignalBdsB2aEna as u32, 0x10310028);
+        assert_eq!(CfgKey::SignalBdsB3Ena as u32, 0x10310010);
+        assert_eq!(CfgKey::SignalQzssL5Ena as u32, 0x10310017);
+        assert_eq!(CfgKey::SignalNavicEna as u32, 0x10310026);
+        assert_eq!(CfgKey::SignalNavicL5Ena as u32, 0x1031001d);
+    }
 }

--- a/ublox/src/ubx_packets/packets/cfg_gnss.rs
+++ b/ublox/src/ubx_packets/packets/cfg_gnss.rs
@@ -90,7 +90,7 @@ impl CfgGnssOwned {
     }
 }
 
-/// Information message config
+/// GNSS constellation identifier used by UBX-CFG-GNSS and related messages.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -103,6 +103,7 @@ pub enum GnssId {
     IMES = 4,
     QZSS = 5,
     GLONASS = 6,
+    NAVIC = 7,
 }
 
 impl TryFrom<u8> for GnssId {
@@ -117,7 +118,8 @@ impl TryFrom<u8> for GnssId {
             4 => Ok(GnssId::IMES),
             5 => Ok(GnssId::QZSS),
             6 => Ok(GnssId::GLONASS),
-            _ => Err("Invalid GnssId value: value must be in range [0, 6]"),
+            7 => Ok(GnssId::NAVIC),
+            _ => Err("Invalid GnssId value: expected 0..=7 (7 = NavIC)"),
         }
     }
 }
@@ -135,6 +137,7 @@ pub enum SigCfgMask {
     Sbas(SbasSigMask),
     Qzss(QzssSigMask),
     Imes(ImesSigMask),
+    Navic(NavicSigMask),
     Unknown(u8),
 }
 
@@ -174,6 +177,12 @@ impl From<ImesSigMask> for SigCfgMask {
     }
 }
 
+impl From<NavicSigMask> for SigCfgMask {
+    fn from(m: NavicSigMask) -> Self {
+        SigCfgMask::Navic(m)
+    }
+}
+
 impl SigCfgMask {
     #[inline]
     pub fn raw_bits(self) -> u8 {
@@ -185,6 +194,7 @@ impl SigCfgMask {
             SigCfgMask::Sbas(m) => m.bits(),
             SigCfgMask::Qzss(m) => m.bits(),
             SigCfgMask::Imes(m) => m.bits(),
+            SigCfgMask::Navic(m) => m.bits(),
             SigCfgMask::Unknown(b) => b,
         }
     }
@@ -263,6 +273,14 @@ bitflags! {
     }
 }
 
+#[ubx_extend_bitflags]
+#[ubx(from, into_raw, rest_reserved)]
+bitflags! {
+    #[derive(Clone, Copy, Debug)]
+    pub struct NavicSigMask: u8 {
+    }
+}
+
 #[derive(Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct GnssConfigBlock {
@@ -337,6 +355,7 @@ impl GnssConfigBlock {
             GnssId::QZSS => SigCfgMask::Qzss(QzssSigMask::from_bits_truncate(m)),
             GnssId::SBAS => SigCfgMask::Sbas(SbasSigMask::from_bits_truncate(m)),
             GnssId::IMES => SigCfgMask::Unknown(m),
+            GnssId::NAVIC => SigCfgMask::Navic(NavicSigMask::from_bits_truncate(m)),
         }
     }
 
@@ -513,5 +532,42 @@ mod tests {
         assert_eq!(parsed[1].gnss_id, GnssId::GALILEO);
         assert_eq!(parsed[0].gnss_id as u8, blocks[0].gnss_id as u8);
         assert_eq!(parsed[1].gnss_id as u8, blocks[1].gnss_id as u8);
+    }
+
+    #[test]
+    fn gnss_id_try_from_navic() {
+        assert_eq!(GnssId::try_from(7u8), Ok(GnssId::NAVIC));
+        assert_eq!(GnssId::NAVIC as u8, 7);
+    }
+
+    #[test]
+    fn gnss_id_try_from_eight_is_err() {
+        // NavIC is gnssId 7 (verified on a live NEO-F10N); 8 is unassigned.
+        assert!(GnssId::try_from(8u8).is_err());
+    }
+
+    #[test]
+    fn gnss_id_try_from_out_of_range_is_err() {
+        assert!(GnssId::try_from(9u8).is_err());
+        assert!(GnssId::try_from(255u8).is_err());
+    }
+
+    #[test]
+    #[cfg(not(feature = "ubx_proto14"))]
+    fn navic_sig_cfg_mask_dispatch() {
+        // sigCfgMask is bits 23..16 of flags.
+        let raw_mask: u8 = 0x11;
+        let block = GnssConfigBlock {
+            gnss_id: GnssId::NAVIC,
+            res_trk_ch: 0,
+            max_trk_ch: 0,
+            reserved1: 0,
+            flags: ((raw_mask as u32) << 16) | 0x01,
+        };
+        assert_eq!(block.raw_sig_mask(), raw_mask);
+        match block.sig_cfg_mask() {
+            SigCfgMask::Navic(m) => assert_eq!(m.bits(), raw_mask),
+            other => panic!("expected SigCfgMask::Navic, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Expands the crate's coverage to L5/L6 bands and NavIC constellations tracked by F10-generation (NEO-F10N/T) and X20-generation (ZED-X20P/D) receivers.

## Changes

_**Breaking Change:** This adds new enum variants to `GnssId` and `SigCfgMask`. Code with exhaustive pattern matches on these enums will require updates._

New `CfgVal` variants:

- SignalGpsL5Ena   (0x10310004)
- SignalGalE5aEna  (0x10310009)
- SignalGalE6Ena   (0x1031000b)  (X20-only)
- SignalBdsB1cEna  (0x1031000f)
- SignalBdsB2aEna  (0x10310028)
- SignalBdsB3Ena   (0x10310010)  (X20-only)
- SignalQzssL5Ena  (0x10310017)
- SignalNavicEna   (0x10310026)
- SignalNavicL5Ena (0x1031001d)

NavIC constellation support:

- GnssId::NAVIC = 7 (UBX gnssId for NavIC/IRNSS)
- NavicSigMask bitflags + SigCfgMask::Navic variant + dispatch arm

Proposed changes pass all tests other than semver ones (due to new enum variants mentioned above).

## Hardware verification

- The seven F10-supported keys (GPS L5, Gal E5a, BDS B1C/B2a, QZSS L5, NavIC, NavIC L5) have been tested and verified using a NEO-F10N board.
- GAL_E6_ENA and BDS_B3_ENA are X20-only. Key IDs have been sourced from the X20 ICD but not yet hardware verified.