### PR TITLE
fix(tim-tm2): shift timeBase before matching in time_base()

### DIFF
--- a/ublox/src/ubx_packets/packets/tim_tm2.rs
+++ b/ublox/src/ubx_packets/packets/tim_tm2.rs
@@ -63,7 +63,7 @@ impl TimTm2Flags {
     }
 
     pub fn time_base(&self) -> TimTm2TimeBase {
-        match self.0 & 0b11000 {
+        match (self.0 >> 3) & 0b11 {
             0 => TimTm2TimeBase::Receiver,
             1 => TimTm2TimeBase::Gnss,
             2 => TimTm2TimeBase::Utc,
@@ -98,4 +98,20 @@ pub enum TimTm2TimeBase {
     Receiver,
     Gnss,
     Utc,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TimTm2Flags, TimTm2TimeBase};
+
+    #[test]
+    fn time_base_decodes_bits_3_and_4() {
+        assert_eq!(TimTm2Flags(0 << 3).time_base(), TimTm2TimeBase::Receiver);
+        assert_eq!(TimTm2Flags(1 << 3).time_base(), TimTm2TimeBase::Gnss);
+        assert_eq!(TimTm2Flags(2 << 3).time_base(), TimTm2TimeBase::Utc);
+        assert_eq!(
+            TimTm2Flags(0b1110_0111).time_base(),
+            TimTm2TimeBase::Receiver
+        );
+    }
 }


### PR DESCRIPTION
`TimTm2Flags::time_base()` masked the `timeBase` field (flags bits 3-4) with
`0b11000` but never shifted it down, so GNSS (raw 1) and UTC (raw 2) masked to
8 and 16 instead of 1 and 2. Calling `time_base()` on a TIM-TM2 message with a
GNSS or UTC time base (any time-mark once the receiver has a fix) therefore hit
`unreachable!()` and panicked; only the receiver-time case (value 0) matched, by
coincidence.

Shift the field down before matching (mirroring `tim_tp.rs::raim_active`) so all
three defined `timeBase` values decode correctly. The reserved value 3 keeps the
existing `unreachable!()` guard, so this is a non-breaking change with no public
API delta. Includes an in-module regression test covering the receiver/GNSS/UTC
bit-patterns.